### PR TITLE
make pytest import local to only be used when a package requests it

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -4,7 +4,6 @@
 import os
 import sys
 
-from _pytest.main import EXIT_NOTESTSCOLLECTED
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_core.task import check_call
@@ -102,5 +101,8 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         if args:
             env['PYTEST_ADDOPTS'] = ' '.join(args)
         rc = await check_call(context, cmd, cwd=context.args.path, env=env)
+
+        # use local import to avoid a dependency on pytest
+        from _pytest.main import EXIT_NOTESTSCOLLECTED
         if rc and rc.returncode != EXIT_NOTESTSCOLLECTED:
             return rc.returncode


### PR DESCRIPTION
When `pytest` is not being installed invoking `colcon` results in the following exception:

```
ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.python_testing.pytest': No module named '_pytest'
Traceback (most recent call last):
  ...
    from _pytest.main import EXIT_NOTESTSCOLLECTED
ImportError: No module named '_pytest'
```

Since exception is being catched it only results in an error message but doesn't prevent the tool from working. As a temporary workaround installing `pytest` will get rid of the error message.

This patch move the import into a local scope so that it is only being used when a package requests `pytest` and therefore has a dependency on `pytest`.