### PR TITLE
use same name for cache as newer versions of pytest

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -55,7 +55,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                 *(Path(context.args.build_base).parts)) / 'pytest.xml'),
             '--junit-prefix=' + context.pkg.name,
             '-o cache_dir=' + str(PurePosixPath(
-                *(Path(context.args.build_base).parts)) / '.cache'),
+                *(Path(context.args.build_base).parts)) / '.pytest_cache'),
         ]
         env = dict(env)
 


### PR DESCRIPTION
The name has been changed in `pytest` version 3.4.0 (in commit https://github.com/pytest-dev/pytest/commit/cd0b2ace6744f1eee8689ca92b5a8453113bf2c5).