### PR TITLE
echo to stderr when sourced file is missing

### DIFF
--- a/colcon_core/shell/template/command_prefix.bat.em
+++ b/colcon_core/shell/template/command_prefix.bat.em
@@ -1,26 +1,9 @@
 :: generated from colcon_core/shell/template/command_prefix.bat.em
 @@echo off
-
 @[for pkg_name, pkg_install_base in dependencies.items()]@
 @{
 import os
 pkg_script = os.path.join(pkg_install_base, 'share', pkg_name, 'package.bat')
 }@
-call:call_file "@(pkg_script)"
-
+call "@(pkg_script)"
 @[end for]@
-if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
-
-goto:eof
-
-
-:: call the specified batch file and output the name when tracing is requested
-:: first argument: the batch file
-:call_file
-  if exist "%~1" (
-    if "%COLCON_TRACE%" NEQ "" echo call "%~1"
-    call "%~1%"
-  ) else (
-    if "%COLCON_TRACE%" NEQ "" echo not found: "%~1"
-  )
-goto:eof

--- a/colcon_core/shell/template/package.bat.em
+++ b/colcon_core/shell/template/package.bat.em
@@ -28,6 +28,6 @@ goto :eof
     if "%COLCON_TRACE%" NEQ "" echo call "%~1"
     call "%~1%"
   ) else (
-    if "%COLCON_TRACE%" NEQ "" echo not found: "%~1"
+    echo not found: "%~1" 1>&2
   )
 goto:eof

--- a/colcon_core/shell/template/package.sh.em
+++ b/colcon_core/shell/template/package.sh.em
@@ -70,9 +70,7 @@ colcon_package_source_shell_script() {
     fi
     . $@@
   else
-    if [ -n "$COLCON_TRACE" ]; then
-      echo "not found: \"$_colcon_package_source_shell_script\""
-    fi
+    echo "not found: \"$_colcon_package_source_shell_script\"" 1>&2
   fi
 
   unset _colcon_package_source_shell_script

--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -20,6 +20,6 @@ goto:eof
     if "%COLCON_TRACE%" NEQ "" echo call "%~1"
     call "%~1%"
   ) else (
-    if "%COLCON_TRACE%" NEQ "" echo not found: "%~1"
+    echo not found: "%~1" 1>&2
   )
 goto:eof

--- a/colcon_core/shell/template/prefix.sh.em
+++ b/colcon_core/shell/template/prefix.sh.em
@@ -14,9 +14,7 @@ colcon_prefix_source_shell_script() {
     fi
     . "$_colcon_prefix_source_shell_script"
   else
-    if [ -n "$COLCON_TRACE" ]; then
-      echo "not found: \"$_colcon_prefix_source_shell_script\""
-    fi
+    echo "not found: \"$_colcon_prefix_source_shell_script\"" 1>&2
   fi
 
   unset _colcon_prefix_source_shell_script


### PR DESCRIPTION
Instead of requiring `COLCON_TRACE` to be set a message is always printed to `stderr` when a file is missing which is supposed to be sourced.