### PR TITLE
use rc 0 when pytest has failing tests

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -109,5 +109,8 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
 
         # use local import to avoid a dependency on pytest
         from _pytest.main import EXIT_NOTESTSCOLLECTED
-        if rc and rc.returncode != EXIT_NOTESTSCOLLECTED:
+        from _pytest.main import EXIT_TESTSFAILED
+        if rc and rc.returncode not in (
+            EXIT_NOTESTSCOLLECTED, EXIT_TESTSFAILED
+        ):
             return rc.returncode

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -152,7 +152,8 @@ class TestVerb(VerbExtensionPoint):
         parser.add_argument(
             '--abort-on-error',
             action='store_true',
-            help='Abort after the first package with any failures')
+            help='Abort after the first package with any errors (failing '
+                 'tests are not considered errors in this context)')
         add_executor_arguments(parser)
         add_event_handler_arguments(parser)
 


### PR DESCRIPTION
`pytest` returns different return codes for several causes (see https://docs.pytest.org/en/latest/usage.html#possible-exit-codes). When any of the tests failed that should not be considered an "error" in terms of invoking the `test` verb. This unifies the return value semantic across other types.

Related to colcon/colcon-cmake#3.