### PR TITLE
enumerate duplicate packages in exception

### DIFF
--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from collections import defaultdict
 import traceback
 
 from colcon_core.logging import colcon_logger
@@ -147,9 +148,18 @@ def get_packages(
         recursive_categories=recursive_categories)
     select_package_decorators(args, decorators)
 
+    # check for duplicate package names
     pkgs = [m.descriptor for m in decorators if m.selected]
     if len({d.name for d in pkgs}) < len(pkgs):
-        raise RuntimeError('Duplicate package names not supported')
+        pkg_paths = defaultdict(list)
+        for d in pkgs:
+            pkg_paths[d.name].append('  - {d.path}'.format_map(locals()))
+        raise RuntimeError(
+            'Duplicate package names not supported:\n' +
+            '\n'.join(
+                ('- ' + name + ':\n' + '\n'.join(sorted(pkg_paths[name])))
+                for name in sorted(pkg_paths.keys())
+                if len(pkg_paths[name]) > 1))
 
     return decorators
 

--- a/test/test_package_selection.py
+++ b/test/test_package_selection.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 from argparse import Namespace
+import os
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_selection import _add_package_selection_arguments
@@ -97,7 +98,10 @@ def test_get_packages():
     ):
         with pytest.raises(RuntimeError) as e:
             get_packages(args)
-        assert str(e).endswith('Duplicate package names not supported')
+        assert 'Duplicate package names not supported:' in str(e.value)
+        assert '- one:' in str(e.value)
+        assert '- {sep}some{sep}path'.format(sep=os.sep) in str(e.value)
+        assert '- {sep}other{sep}path'.format(sep=os.sep) in str(e.value)
 
 
 def test__check_package_selection_parameters():


### PR DESCRIPTION
To provide useful feedback to the user in case this happens.