### PR TITLE
create relative symlink for latest

### DIFF
--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -144,4 +144,9 @@ def create_log_path():
         if latest.is_symlink():
             os.remove(str(latest))
 
+        # use relative path when possible
+        try:
+            path = path.relative_to(latest.parent)
+        except ValueError as e:
+            pass
         os.symlink(str(path), str(latest))


### PR DESCRIPTION
Create a relative symlink for the `latest` log directory when possible.

That makes the symlink valid when it is e.g. created in a mounted Docker volumn where the absolute path inside the Docker would not be valid outside of Docker.