### PR TITLE
use dash for build/run/test dependencies

### DIFF
--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -141,7 +141,7 @@ def update_descriptor(
                 desc.dependencies[dep_type].add(d)
     # transfer type specific dependencies
     for dep_type in dep_types:
-        key = '{dep_type}_dependencies'.format_map(locals())
+        key = '{dep_type}-dependencies'.format_map(locals())
         if key in data:
             for d in data[key]:
                 desc.dependencies[dep_type].add(d)
@@ -157,7 +157,7 @@ def update_descriptor(
         additional_argument_names -= {
             'name', 'type', 'dependencies', 'hooks'}
         additional_argument_names -= {
-            '{dep_type}_dependencies'.format_map(locals())
+            '{dep_type}-dependencies'.format_map(locals())
             for dep_type in dep_types}
     for key in (additional_argument_names or []):
         if key in data:

--- a/test/test_package_augmentation.py
+++ b/test/test_package_augmentation.py
@@ -107,8 +107,8 @@ def test_update_descriptor():
     assert len(desc.metadata) == 0
 
     data = {
-        'build_dependencies': {'b1', 'b2'},
-        'test_dependencies': {'t1'},
+        'build-dependencies': {'b1', 'b2'},
+        'test-dependencies': {'t1'},
     }
     update_descriptor(desc, data)
     assert len(desc.dependencies) == 2


### PR DESCRIPTION
To match other options derived from command line arguments and as documented in colcon/colcon.readthedocs.org#5.