### PR TITLE
modify destination collector to store option as well as destination

### DIFF
--- a/colcon_core/argument_parser/destination_collector.py
+++ b/colcon_core/argument_parser/destination_collector.py
@@ -1,11 +1,13 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from collections import OrderedDict
+
 from colcon_core.argument_parser import ArgumentParserDecorator
 
 
 class DestinationCollectorDecorator(ArgumentParserDecorator):
-    """Collect destinations of arguments."""
+    """Collect the option names and destination of arguments."""
 
     def __init__(self, parser):
         """
@@ -17,7 +19,7 @@ class DestinationCollectorDecorator(ArgumentParserDecorator):
         # pass them as keyword arguments instead
         super().__init__(
             parser,
-            _destinations=[])
+            _destinations=OrderedDict())
 
     def get_destinations(self):
         """
@@ -26,16 +28,21 @@ class DestinationCollectorDecorator(ArgumentParserDecorator):
         :returns: The destination names
         :rtype: list
         """
-        destinations = []
-        destinations += self._destinations
+        destinations = OrderedDict()
+        destinations.update(self._destinations)
         for d in self._nested_decorators:
-            destinations += d.get_destinations()
+            destinations.update(d.get_destinations())
         return destinations
 
     def add_argument(self, *args, **kwargs):
-        """Collect destinations for all added arguments."""
+        """Collect option names and destination for all added arguments."""
         argument = self._parser.add_argument(*args, **kwargs)
 
-        self._destinations.append(argument.dest)
+        for arg in args:
+            if not arg.startswith('-'):
+                continue
+            key = arg.lstrip('-')
+            assert key not in self._destinations
+            self._destinations[key] = argument.dest
 
         return argument

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -212,8 +212,8 @@ class BuildVerb(VerbExtensionPoint):
                 recursive_dependencies[dep_name] = dep_path
 
             package_args = BuildPackageArguments(
-                pkg, args,
-                additional_destinations=self.task_argument_destinations)
+                pkg, args, additional_destinations=self
+                .task_argument_destinations.values())
             ordered_package_args = ', '.join([
                 ('%s: %s' % (repr(k), repr(package_args.__dict__[k])))
                 for k in sorted(package_args.__dict__.keys())

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -162,8 +162,10 @@ class TestVerb(VerbExtensionPoint):
         decorated_parser = DestinationCollectorDecorator(parser)
         add_task_arguments(decorated_parser, 'test')
         self.task_argument_destinations = decorated_parser.get_destinations()
-        self.task_argument_destinations += (
-            'retest_until_pass', 'retest_until_fail')
+        self.task_argument_destinations['retest-until-pass'] = \
+            'retest_until_pass'
+        self.task_argument_destinations['retest-until-fail'] = \
+            'retest_until_fail'
 
     def main(self, *, context):  # noqa: D102
         check_and_mark_build_tool(context.args.build_base)
@@ -203,8 +205,8 @@ class TestVerb(VerbExtensionPoint):
                 recursive_dependencies[dep_name] = dep_path
 
             package_args = TestPackageArguments(
-                pkg, args,
-                additional_destinations=self.task_argument_destinations)
+                pkg, args, additional_destinations=self
+                .task_argument_destinations.values())
             ordered_package_args = ', '.join([
                 ('%s: %s' % (repr(k), repr(package_args.__dict__[k])))
                 for k in sorted(package_args.__dict__.keys())

--- a/test/test_destination_collector.py
+++ b/test/test_destination_collector.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import argparse
+from collections import OrderedDict
 
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
@@ -10,11 +11,13 @@ from colcon_core.argument_parser.destination_collector \
 def test_destination_collector_decorator():
     parser = argparse.ArgumentParser()
     decorator = DestinationCollectorDecorator(parser)
-    assert decorator.get_destinations() == []
+    decorator.add_argument('positional')
+    assert decorator.get_destinations() == {}
 
     decorator.add_argument('--option', action='store_true')
-    assert decorator.get_destinations() == ['option']
+    assert decorator.get_destinations() == OrderedDict([('option', 'option')])
 
     group = decorator.add_mutually_exclusive_group()
     group.add_argument('--other-option', action='store_true')
-    assert decorator.get_destinations() == ['option', 'other_option']
+    assert decorator.get_destinations() == OrderedDict([
+        ('option', 'option'), ('other-option', 'other_option')])


### PR DESCRIPTION
Related to colcon/colcon.readthedocs.org#5.

This patch modifies the destination collector to save the name of the command line options as well as the destination. That allows that configuration files can use the same spelling as the command line options (as well as e.g. a short version of the argument) while the internal logic uses the destination name for valid variables names.