### PR TITLE
also force flush on stderr

### DIFF
--- a/colcon_core/event_handler/console_direct.py
+++ b/colcon_core/event_handler/console_direct.py
@@ -43,3 +43,4 @@ class ConsoleDirectEventHandler(EventHandlerExtensionPoint):
                 sys.stderr.buffer.write(data.line)
             else:
                 sys.stderr.write(data.line)
+            sys.stderr.flush()


### PR DESCRIPTION
I was under the impression `stderr` would by default be line buffered. That doesn't seem to be the case. Therefore this patch flushes `stderr` the same way as `stdout` a few lines above.

Fixes #27. Connect to colcon/colcon-core#27.