### PR TITLE
add a log file containing all log messages

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -25,6 +25,7 @@ env
 eof
 epilog
 fd
+filehandler
 html
 https
 isatty


### PR DESCRIPTION
This provide more debugging information even in the case where the tool was invoked without any custom log level.