### PR TITLE
fix showing Python testing extensions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ colcon_core.extension_point =
     colcon_core.package_discovery = colcon_core.package_discovery:PackageDiscoveryExtensionPoint
     colcon_core.package_identification = colcon_core.package_identification:PackageIdentificationExtensionPoint
     colcon_core.package_selection = colcon_core.package_selection:PackageSelectionExtensionPoint
+    colcon_core.python_testing = colcon_core.task.python.test:PythonTestingStepExtensionPoint
     colcon_core.shell = colcon_core.shell:ShellExtensionPoint
     colcon_core.task.build = colcon_core.task:TaskExtensionPoint
     colcon_core.task.test = colcon_core.task:TaskExtensionPoint


### PR DESCRIPTION
Before the `colcon_core.python_testing` extensions were not listed in the `extensions` / `extension-point` verbs.