### PR TITLE
use newer pytest(-cov) features only when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - pip install -U EmPy
   # tests_require
   - if [ "$TEST_SUITE" = "pytest" ]; then pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pyenchant pylint pytest pytest-cov; fi
-  # colcon test needs pytest-runner
-  - if [ "$TEST_SUITE" = "bootstrap" ]; then pip install -U pytest-runner; fi
+  # colcon test needs pytest-cov and pytest-runner
+  - if [ "$TEST_SUITE" = "bootstrap" ]; then pip install -U pytest-cov pytest-runner; fi
   # for uploading the coverage information to codecov
   - if [ "$TEST_SUITE" = "pytest" ]; then pip install codecov; fi
 script:

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -14,6 +14,7 @@ cmd
 colcon
 config
 const
+cov
 cwd
 decoree
 desc


### PR DESCRIPTION
* `-o ...` as of `pytest` version 3.3.0
* `--cov-branch` as of `pytest-cov` version 2.5.0