### PR TITLE
rename SkipLocationException to IgnoreLocationException

### DIFF
--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -8,7 +8,7 @@ import sys
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
-from colcon_core.package_identification import SkipLocationException
+from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.plugin_system import satisfies_version
 
 
@@ -59,7 +59,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
 
             try:
                 result = identify(identification_extensions, real_path)
-            except SkipLocationException:
+            except IgnoreLocationException:
                 continue
             if result:
                 descs.add(result)

--- a/colcon_core/package_identification/__init__.py
+++ b/colcon_core/package_identification/__init__.py
@@ -14,7 +14,7 @@ from colcon_core.plugin_system import order_extensions_grouped_by_priority
 logger = colcon_logger.getChild(__name__)
 
 
-class SkipLocationException(Exception):
+class IgnoreLocationException(Exception):
     """
     Exception to signal that a path should be skipped.
 
@@ -58,7 +58,7 @@ class PackageIdentificationExtensionPoint:
         :param desc: The package descriptor with the directory to check
         :type desc:
           :py:class:`colcon_core.package_descriptor.PackageDescriptor`
-        :raises SkipLocationException: Skip the path as well as all recursive
+        :raises IgnoreLocationException: Skip the path as well as all recursive
           subdirectories
         """
         raise NotImplementedError()
@@ -106,7 +106,7 @@ def identify(
 
         # skip location since identification is ambiguous
         if result is False:
-            raise SkipLocationException()
+            raise IgnoreLocationException()
 
         assert isinstance(result, PackageDescriptor), result
         if result.identifies_package():
@@ -134,7 +134,7 @@ def _identify(extensions_same_prio, desc):
         try:
             retval = extension.identify(desc2)
             assert retval is None, 'identify() should return None'
-        except SkipLocationException:
+        except IgnoreLocationException:
             logger.log(1, '_identify(%s) ignored', desc.path)
             raise
         except Exception as e:

--- a/colcon_core/package_identification/ignore.py
+++ b/colcon_core/package_identification/ignore.py
@@ -3,7 +3,7 @@
 
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
-from colcon_core.package_identification import SkipLocationException
+from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.plugin_system import satisfies_version
 
 IGNORE_MARKER = 'COLCON_IGNORE'
@@ -24,4 +24,4 @@ class IgnorePackageIdentification(PackageIdentificationExtensionPoint):
     def identify(self, desc):  # noqa: D102
         colcon_ignore = desc.path / IGNORE_MARKER
         if colcon_ignore.exists():
-            raise SkipLocationException()
+            raise IgnoreLocationException()

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_discovery.path import _expand_wildcards
 from colcon_core.package_discovery.path import PathPackageDiscovery
-from colcon_core.package_identification import SkipLocationException
+from colcon_core.package_identification import IgnoreLocationException
 from mock import Mock
 from mock import patch
 
@@ -39,7 +39,7 @@ def identify(_, path):
     if path == os.path.realpath('/empty/path'):
         return None
     if path == os.path.realpath('/skip/path'):
-        raise SkipLocationException()
+        raise IgnoreLocationException()
     return PackageDescriptor(path)
 
 

--- a/test/test_package_identification.py
+++ b/test/test_package_identification.py
@@ -10,7 +10,7 @@ from colcon_core.package_identification \
 from colcon_core.package_identification import identify
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
-from colcon_core.package_identification import SkipLocationException
+from colcon_core.package_identification import IgnoreLocationException
 from mock import Mock
 from mock import patch
 import pytest
@@ -90,8 +90,8 @@ def test_identify():
         # skip location
         extensions = get_package_identification_extensions()
         extensions[90]['extension3'].identify = Mock(
-            side_effect=SkipLocationException())
-        with pytest.raises(SkipLocationException):
+            side_effect=IgnoreLocationException())
+        with pytest.raises(IgnoreLocationException):
             identify(extensions, path)
 
         # valid result from first priority group
@@ -112,7 +112,7 @@ def test_identify():
             side_effect=identify_name)
         extensions[100]['extension4'].identify = Mock(
             side_effect=identify_type)
-        with pytest.raises(SkipLocationException):
+        with pytest.raises(IgnoreLocationException):
             identify(extensions, path)
 
 
@@ -168,8 +168,8 @@ def test__identify():
         # skip location
         extensions = get_package_identification_extensions()[90]
         extensions['extension3'].identify = Mock(
-            side_effect=SkipLocationException())
-        with pytest.raises(SkipLocationException):
+            side_effect=IgnoreLocationException())
+        with pytest.raises(IgnoreLocationException):
             _identify(extensions, desc_path_only)
 
         # raise exception

--- a/test/test_package_identification_ignore.py
+++ b/test/test_package_identification_ignore.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from colcon_core.package_identification import SkipLocationException
+from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.package_identification.ignore import IGNORE_MARKER
 from colcon_core.package_identification.ignore \
     import IgnorePackageIdentification
@@ -20,5 +20,5 @@ def test_identify():
         assert extension.identify(metadata) is None
 
         (metadata.path / IGNORE_MARKER).write_text('')
-        with pytest.raises(SkipLocationException):
+        with pytest.raises(IgnoreLocationException):
             extension.identify(metadata)


### PR DESCRIPTION
Since the semantic of "skip" and "ignore" is different within the command line arguments the exception should follow the same meaning in order to not confuse the developer.