### PR TITLE
add additional logging into sequential executor and event reactor

### DIFF
--- a/colcon_core/event_reactor.py
+++ b/colcon_core/event_reactor.py
@@ -100,8 +100,10 @@ class EventReactor(Thread):
         An :class:`EventReactorShutdown` event is added to the queue to notify
         all observers that the event reactor is about to shut down.
         """
+        logger.debug('joining thread')
         self._queue.put((EventReactorShutdown(), None))
         super().join(*args, **kwargs)
+        logger.debug('joined thread')
 
 
 class EventReactorShutdown:

--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -4,11 +4,15 @@
 import asyncio
 import logging
 import signal
+import traceback
 
 from colcon_core.executor import ExecutorExtensionPoint
+from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.subprocess import new_event_loop
 from colcon_core.subprocess import SIGINT_RESULT
+
+logger = colcon_logger.getChild(__name__)
 
 
 class SequentialExecutor(ExecutorExtensionPoint):
@@ -25,31 +29,47 @@ class SequentialExecutor(ExecutorExtensionPoint):
 
     def execute(self, args, jobs, *, abort_on_error=True):  # noqa: D102
         # avoid debug message from asyncio when colcon uses debug log level
-        logger = logging.getLogger('asyncio')
-        logger.setLevel(logging.INFO)
+        asyncio_logger = logging.getLogger('asyncio')
+        asyncio_logger.setLevel(logging.INFO)
 
         rc = 0
         loop = new_event_loop()
         asyncio.set_event_loop(loop)
         try:
-            for job in jobs.values():
+            for name, job in jobs.items():
                 coro = job()
                 future = asyncio.ensure_future(coro, loop=loop)
                 try:
+                    logger.debug(
+                        "run_until_complete '{name}'".format_map(locals()))
                     loop.run_until_complete(future)
                 except KeyboardInterrupt:
+                    logger.debug(
+                        "run_until_complete '{name}' was interrupted, "
+                        'run_until_complete again'.format_map(locals()))
                     # override job rc with special SIGINT value
                     job.returncode = SIGINT_RESULT
                     # ignore further SIGINTs
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
                     # wait for job which has also received a SIGINT
                     loop.run_until_complete(future)
+                    logger.debug(
+                        "run_until_complete '{name}' finished"
+                        .format_map(locals()))
                     raise
-                except Exception:
+                except Exception as e:
+                    exc = traceback.format_exc()
+                    logger.error(
+                        "Exception in job execution '{name}': {e}\n{exc}"
+                        .format_map(locals()))
                     return 1
-                if future.result():
+                result = future.result()
+                logger.debug(
+                    "run_until_complete '{name}' finished with '{result}'"
+                    .format_map(locals()))
+                if result:
                     if not rc:
-                        rc = future.result()
+                        rc = result
                     if abort_on_error:
                         return rc
         finally:


### PR DESCRIPTION
Hoping to have more information at hand when an invocation "hangs" in the future.