### PR TITLE
allow passing through kwargs in destination collector

### DIFF
--- a/colcon_core/argument_parser/destination_collector.py
+++ b/colcon_core/argument_parser/destination_collector.py
@@ -9,7 +9,7 @@ from colcon_core.argument_parser import ArgumentParserDecorator
 class DestinationCollectorDecorator(ArgumentParserDecorator):
     """Collect the option names and destination of arguments."""
 
-    def __init__(self, parser):
+    def __init__(self, parser, **kwargs):
         """
         Constructor.
 
@@ -19,7 +19,8 @@ class DestinationCollectorDecorator(ArgumentParserDecorator):
         # pass them as keyword arguments instead
         super().__init__(
             parser,
-            _destinations=OrderedDict())
+            _destinations=OrderedDict(),
+            **kwargs)
 
     def get_destinations(self):
         """


### PR DESCRIPTION
Necessary for colcon/colcon-defaults#5. Connect to colcon/colcon-defaults#5.