### PR TITLE
remove unavailable dependencies in Debian patch

### DIFF
--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -1,0 +1,21 @@
+Description: Remove dependencies unavailable from Debian packages
+ Otherwise being listed there but not being installed would result in a
+ runtime error by pkg_resources.
+Author: Dirk Thomas <web@dirk-thomas.net>
+
+--- setup.cfg	2018-05-27 11:22:33.000000000 -0700
++++ setup.cfg.patched	2018-05-27 11:22:33.000000000 -0700
+@@ -31,8 +31,11 @@
+ 	EmPy
+ 	pytest
+ 	pytest-cov
+-	pytest-repeat
+-	pytest-rerunfailures
++	# the following dependencies are not available from Debian
++	# so listing them here but not installing them in the Debian package
++	# would result in a runtime error by pkg_resources
++	# pytest-repeat
++	# pytest-rerunfailures
+ 	setuptools
+ packages = find:
+ tests_require = 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import os
 import sys
 
 from pkg_resources import parse_version
@@ -13,4 +14,48 @@ if (
 ):
     sys.exit('This package requires at least Python ' + minimum_version)
 
-setup()
+cmdclass = {}
+try:
+    from stdeb.command.sdist_dsc import sdist_dsc
+except ImportError:
+    pass
+else:
+    class CustomSdistDebCommand(sdist_dsc):
+        """Weird approach to apply the Debian patches during packaging."""
+
+        def run(self):  # noqa: D102
+            from stdeb.command import sdist_dsc
+            build_dsc = sdist_dsc.build_dsc
+
+            def custom_build_dsc(*args, **kwargs):
+                nonlocal build_dsc
+                debinfo = self.get_debinfo()
+                repackaged_dirname = \
+                    debinfo.source + '-' + debinfo.upstream_version
+                dst_directory = os.path.join(
+                    self.dist_dir, repackaged_dirname, 'debian', 'patches')
+                os.makedirs(dst_directory, exist_ok=True)
+                # read patch
+                with open('debian/patches/setup.cfg.patch', 'r') as h:
+                    lines = h.read().splitlines()
+                print(
+                    "writing customized patch '%s'" %
+                    os.path.join(dst_directory, 'setup.cfg.patch'))
+                # write patch with modified path
+                with open(
+                    os.path.join(dst_directory, 'setup.cfg.patch'), 'w'
+                ) as h:
+                    for line in lines:
+                        if line.startswith('--- ') or line.startswith('+++ '):
+                            line = \
+                                line[0:4] + repackaged_dirname + '/' + line[4:]
+                        h.write(line + '\n')
+                with open(os.path.join(dst_directory, 'series'), 'w') as h:
+                    h.write('setup.cfg.patch\n')
+                return build_dsc(*args, **kwargs)
+
+            sdist_dsc.build_dsc = custom_build_dsc
+            super().run()
+    cmdclass['sdist_dsc'] = CustomSdistDebCommand
+
+setup(cmdclass=cmdclass)


### PR DESCRIPTION
Everything but straight forward approach to apply a patch during the Debian packaging steps.

The patch removes the optional dependencies which are not available from Debian packages from the `install_requires`.