### PR TITLE
override argument parser to fallback to args rather than options

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -139,8 +139,21 @@ def create_parser(environment_variables_group_name):
       the environment variable extensions
     :returns: The argument parser
     """
+    # workaround a limitation in argparse to accept arguments to options
+    # which begin with a dash but are not options themselves
+    # https://bugs.python.org/issue9334
+    class CustomArgumentParser(argparse.ArgumentParser):
+
+        def _parse_optional(self, arg_string):
+            result = super()._parse_optional(arg_string)
+            if result == (None, arg_string, None):
+                # in the case there the arg is classified as an unknown 'O'
+                # override that and classify it as an 'A'
+                return None
+            return result
+
     # top level parser
-    parser = argparse.ArgumentParser(
+    parser = CustomArgumentParser(
         formatter_class=CustomFormatter,
         epilog=get_environment_variables_epilog(
             environment_variables_group_name))

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -37,7 +37,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         parser.add_argument(
             '--pytest-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Pass arguments to all pytests. '
+            help='Pass arguments to pytests. '
             'Arguments matching other options must be prefixed by a space,\n'
             'e.g. --pytest-args " --help"')
 

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -37,9 +37,9 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         parser.add_argument(
             '--pytest-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help='Pass arguments to all pytests. Every arg starting with a '
-            'dash must be prefixed by a space,\n'
-            'e.g. --pytest-args " --showlocals"')
+            help='Pass arguments to all pytests. '
+            'Arguments matching other options must be prefixed by a space,\n'
+            'e.g. --pytest-args " --help"')
 
     def match(self, context, env, setup_py_data):  # noqa: D102
         return has_test_dependency(setup_py_data, 'pytest')

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -4,6 +4,7 @@
 import signal
 
 from colcon_core.command import CommandContext
+from colcon_core.command import create_parser
 from colcon_core.command import main
 from colcon_core.command import verb_main
 from colcon_core.environment_variable import EnvironmentVariable
@@ -62,6 +63,23 @@ def test_main():
                 }
             ):
                 main(argv=['extension1'])
+
+
+def test_create_parser():
+    with EntryPointContext():
+        parser = create_parser('colcon_core.environment_variable')
+
+    parser.add_argument('--foo', nargs='*', type=str.lstrip)
+    args = parser.parse_args(['--foo', '--bar', '--baz'])
+    assert args.foo == ['--bar', '--baz']
+
+    parser.add_argument('--baz', action='store_true')
+    args = parser.parse_args(['--foo', '--bar', '--baz'])
+    assert args.foo == ['--bar']
+    assert args.baz is True
+
+    args = parser.parse_args(['--foo', '--bar', ' --baz'])
+    assert args.foo == ['--bar', '--baz']
 
 
 class Object(object):


### PR DESCRIPTION
Fixes #36.

This is an "interesting" approach to monkey patch the change proposed upstream.

I will put this in review for people to try and comment on the patch. Once it is approved the help texts can be updated to mention the space prefix only for cases the the arguments are actually valid options of `colcon`.