### PR TITLE
declare flake8 import order style

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -120,3 +120,6 @@ console_scripts =
 
 [options.package_data]
 colcon_core.shell.template = *.em
+
+[flake8]
+import-order-style = google


### PR DESCRIPTION
To avoid relying on other (potentially user specific) configurations.