### PR TITLE
create file with run deps for each package, use these for sourcing packages in topological order

### DIFF
--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -67,6 +67,9 @@ def create_environment_scripts(
     """
     Create the environment scripts for a package.
 
+    Also create a file with the runtime dependencies of each packages which can
+    be used by the prefix scripts to source all packages in topological order.
+
     :param pkg: The package descriptor
     :param args: The parsed command line arguments
     :param list default_hooks: If none are parsed explicitly the hooks provided
@@ -118,6 +121,12 @@ def create_environment_scripts(
                     "Exception in shell extension '{extension.SHELL_NAME}': "
                     '{e}\n{exc}'.format_map(locals()))
                 # skip failing extension, continue with next one
+
+    # create file containing the runtime dependencies
+    path = prefix_path / 'share' / 'colcon_core' / 'packages' / pkg.name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        os.pathsep.join(sorted(pkg.dependencies.get('run', set()))))
 
 
 def create_environment_hooks(prefix_path, pkg_name):

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -35,7 +35,7 @@ class ShellExtensionPoint:
     """
 
     """The version of the shell extension interface."""
-    EXTENSION_POINT_VERSION = '1.0'
+    EXTENSION_POINT_VERSION = '2.0'
 
     """
     The default priority of shell extensions.
@@ -53,7 +53,7 @@ class ShellExtensionPoint:
     """
     PRIORITY = 100
 
-    def create_prefix_script(self, prefix_path, pkg_names, merge_install):
+    def create_prefix_script(self, prefix_path, merge_install):
         """
         Create a script in the install prefix path.
 
@@ -62,11 +62,19 @@ class ShellExtensionPoint:
         This method must be overridden in a subclass.
 
         :param Path prefix_path: The path of the install prefix
-        :param list pkg_names: The package names
         :param bool merge_install: The flag if all packages share the same
           install prefix
         """
         raise NotImplementedError()
+
+    def _get_prefix_util_path(self):
+        """
+        Get the absolute path of the `prefix_util.py` module.
+
+        :returns: The path of the module file
+        :rtype: Path
+        """
+        return Path(__file__).parent / 'template' / 'prefix_util.py'
 
     def create_package_script(self, prefix_path, pkg_name, hooks):
         """

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from pathlib import Path
+import shutil
 import sys
 
 from colcon_core import shell
@@ -23,23 +24,24 @@ class BatShell(ShellExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.0')
         if sys.platform != 'win32' and not shell.use_all_shell_extensions:
             raise SkipExtensionException('Not used on non-Windows systems')
 
-    def create_prefix_script(
-        self, prefix_path, pkg_names, merge_install
-    ):  # noqa: D102
+    def create_prefix_script(self, prefix_path, merge_install):  # noqa: D102
         prefix_env_path = prefix_path / 'local_setup.bat'
         logger.info("Creating prefix script '%s'" % prefix_env_path)
         expand_template(
             Path(__file__).parent / 'template' / 'prefix.bat.em',
             prefix_env_path,
             {
-                'pkg_names': pkg_names,
+                'python_executable': sys.executable,
                 'merge_install': merge_install,
                 'package_script_no_ext': 'package',
             })
+        shutil.copy(
+            str(self._get_prefix_util_path()),
+            str(prefix_path / '_local_setup_util.py'))
 
         prefix_chain_env_path = prefix_path / 'setup.bat'
         logger.info(

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from pathlib import Path
+import shutil
 import sys
 
 from colcon_core import shell
@@ -23,13 +24,11 @@ class ShShell(ShellExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.0')
         if sys.platform == 'win32' and not shell.use_all_shell_extensions:
             raise SkipExtensionException('Not used on Windows systems')
 
-    def create_prefix_script(
-        self, prefix_path, pkg_names, merge_install
-    ):  # noqa: D102
+    def create_prefix_script(self, prefix_path, merge_install):  # noqa: D102
         prefix_env_path = prefix_path / 'local_setup.sh'
         logger.info("Creating prefix script '%s'" % prefix_env_path)
         expand_template(
@@ -37,10 +36,13 @@ class ShShell(ShellExtensionPoint):
             prefix_env_path,
             {
                 'prefix_path': prefix_path,
-                'pkg_names': pkg_names,
+                'python_executable': sys.executable,
                 'merge_install': merge_install,
                 'package_script_no_ext': 'package',
             })
+        shutil.copy(
+            str(self._get_prefix_util_path()),
+            str(prefix_path / '_local_setup_util.py'))
 
         prefix_chain_env_path = prefix_path / 'setup.sh'
         logger.info(

--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -6,13 +6,17 @@
 
 :: add this prefix to the COLCON_PREFIX_PATH
 call:_colcon_prefix_bat_prepend_unique_value COLCON_PREFIX_PATH "%%~dp0"
-@[if pkg_names]@
+
+:: get all packages in topological order
+call:ament_get_ordered_packages _ordered_packages "%~dp0"
 
 :: source packages
-@[  for pkg_name in pkg_names]@
-call:_colcon_prefix_bat_call_script "%%~dp0@('' if merge_install else (pkg_name + '\\'))share\@(pkg_name)\@(package_script_no_ext).bat"
-@[  end for]@
-@[end if]@
+if "%_ordered_packages%" NEQ "" (
+  for %%p in ("%_ordered_packages:;=";"%") do (
+    call:_colcon_prefix_bat_call_script "%%~dp0@('' if merge_install else '%%~p\\')share\%%~p\@(package_script_no_ext).bat"
+  )
+  set "_ordered_packages="
+)
 
 goto:eof
 
@@ -49,6 +53,36 @@ goto:eof
   :: set result variable in parent scope
   endlocal & (
     set "%~1=%all_values%"
+  )
+goto:eof
+
+
+:: Get the package names in topological order
+:: using semicolons as separators and avoiding leading separators.
+:: first argument: the name of the result variable
+:: second argument: the base path to look for packages
+:ament_get_ordered_packages
+  setlocal enabledelayedexpansion
+
+  :: use the Python executable known at configure time
+  set "_colcon_python_executable=@(python_executable)"
+  :: allow overriding it with a custom location
+  if "%COLCON_PYTHON_EXECUTABLE%" NEQ "" (
+    set "_colcon_python_executable=%COLCON_PYTHON_EXECUTABLE%"
+  )
+
+  set "_colcon_ordered_packages="
+  for /f %%p in ('""%_colcon_python_executable%" "%~dp0_local_setup_util.py"@
+@[if merge_install]@
+ --merged-install@
+@[end if]@
+"') do (
+    if "!_colcon_ordered_packages!" NEQ "" set "_colcon_ordered_packages=!_colcon_ordered_packages!;"
+    set "_colcon_ordered_packages=!_colcon_ordered_packages!%%p"
+  )
+  endlocal & (
+    :: set result variable in parent scope
+    set "%~1=%_colcon_ordered_packages%"
   )
 goto:eof
 

--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -13,7 +13,7 @@ call:ament_get_ordered_packages _ordered_packages "%~dp0"
 :: source packages
 if "%_ordered_packages%" NEQ "" (
   for %%p in ("%_ordered_packages:;=";"%") do (
-    call:_colcon_prefix_bat_call_script "%%~dp0@('' if merge_install else '%%~p\\')share\%%~p\@(package_script_no_ext).bat"
+    call:_colcon_prefix_bat_call_script "%~dp0@('' if merge_install else '%%~p\\')share\%%~p\@(package_script_no_ext).bat"
   )
   set "_ordered_packages="
 )

--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -8,7 +8,7 @@
 call:_colcon_prefix_bat_prepend_unique_value COLCON_PREFIX_PATH "%%~dp0"
 
 :: get all packages in topological order
-call:ament_get_ordered_packages _ordered_packages "%~dp0"
+call:_colcon_get_ordered_packages _ordered_packages "%~dp0"
 
 :: source packages
 if "%_ordered_packages%" NEQ "" (
@@ -61,7 +61,7 @@ goto:eof
 :: using semicolons as separators and avoiding leading separators.
 :: first argument: the name of the result variable
 :: second argument: the base path to look for packages
-:ament_get_ordered_packages
+:_colcon_get_ordered_packages
   setlocal enabledelayedexpansion
 
   :: use the Python executable known at configure time

--- a/colcon_core/shell/template/prefix_util.py
+++ b/colcon_core/shell/template/prefix_util.py
@@ -1,0 +1,136 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+
+def main(argv=sys.argv[1:]):  # noqa: D103
+    parser = argparse.ArgumentParser(
+        description='Output found packages in topological order')
+    parser.add_argument(
+        '--merged-install', action='store_true',
+        help='All install prefixes are merged into a single location')
+    args = parser.parse_args(argv)
+
+    packages = get_packages(Path(__file__).parent, args.merged_install)
+
+    for pkg_name in order_packages(packages):
+        print(pkg_name)
+
+
+def get_packages(prefix_path, merged_install):
+    """
+    Find packages based on colcon-specific files created during installation.
+
+    :param Path prefix_path: The install prefix path of all packages
+    :param bool merged_install: The flag if the packages are all installed
+      directly in the prefix or if each package is installed in a subdirectory
+      named after the package
+    :returns: A mapping from the package name to the set of runtime
+      dependencies
+    :rtype: dict
+    """
+    packages = {}
+    subdirectory = 'share/colcon_core/packages'
+    if merged_install:
+        # find all files in the subdirectory
+        for p in (prefix_path / subdirectory).iterdir():
+            if not p.is_file():
+                continue
+            if p.name.startswith('.'):
+                continue
+            add_package(p, packages)
+    else:
+        # for each subdirectory look for the package specific file
+        for p in prefix_path.iterdir():
+            if not p.is_dir():
+                continue
+            if p.name.startswith('.'):
+                continue
+            p = p / subdirectory / p.name
+            add_package(p, packages)
+
+    # remove unknown dependencies
+    pkg_names = set(packages.keys())
+    for k in packages.keys():
+        packages[k] = {d for d in packages[k] if d in pkg_names}
+
+    return packages
+
+
+def add_package(path, packages):
+    """
+    Check the path and if it exists extract the packages runtime dependencies.
+
+    :param Path path: The resource file containing the runtime dependencies
+    :param dict packages: A mapping from package names to the sets of runtime
+      dependencies to add to
+    """
+    if not path.exists() or not path.is_file():
+        return
+    content = path.read_text()
+    dependencies = set(content.split(os.pathsep) if content else [])
+    packages[path.name] = dependencies
+
+
+def order_packages(packages):
+    """
+    Order packages topologically.
+
+    :param Path path: The resource file containing the runtime dependencies
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies
+    :returns: The package names
+    :rtype: list
+    """
+    # select packages with no dependencies in alphabetical order
+    to_be_ordered = list(packages.keys())
+    ordered = []
+    while to_be_ordered:
+        pkg_names_without_deps = [
+            name for name in to_be_ordered if not packages[name]]
+        if not pkg_names_without_deps:
+            reduce_cycle_set(packages)
+            raise RuntimeError(
+                'Circular dependency between: ' + ', '.join(sorted(packages)))
+        pkg_names_without_deps.sort()
+        pkg_name = pkg_names_without_deps[0]
+        to_be_ordered.remove(pkg_name)
+        ordered.append(pkg_name)
+        # remove item from dependency lists
+        for k in list(packages.keys()):
+            if pkg_name in packages[k]:
+                packages[k].remove(pkg_name)
+    return ordered
+
+
+def reduce_cycle_set(packages):
+    """
+    Reduce the set of packages to the ones part of the circular dependency.
+
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies which is modified in place
+    """
+    last_depended = None
+    while len(packages) > 0:
+        # get all remaining dependencies
+        depended = set()
+        for pkg_name, dependencies in packages.items():
+            depended = depended.union(dependencies)
+        # remove all packages which are not dependent on
+        for name in list(packages.keys()):
+            if name not in depended:
+                del packages[name]
+        if last_depended:
+            # if remaining packages haven't changed return them
+            if last_depended == depended:
+                return packages.keys()
+        # otherwise reduce again
+        last_depended = depended
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -172,8 +172,7 @@ class BuildVerb(VerbExtensionPoint):
 
         rc = execute_jobs(context, jobs)
 
-        self._create_prefix_scripts(
-            install_base, decorators, context.args.merge_install)
+        self._create_prefix_scripts(install_base, context.args.merge_install)
 
         return rc
 
@@ -233,17 +232,14 @@ class BuildVerb(VerbExtensionPoint):
             jobs[pkg.name] = job
         return jobs
 
-    def _create_prefix_scripts(
-        self, install_base, decorators, merge_install,
-    ):
-        ordered_pkg_names = [m.descriptor.name for m in decorators]
+    def _create_prefix_scripts(self, install_base, merge_install):
         extensions = get_shell_extensions()
         for priority in extensions.keys():
             extensions_same_prio = extensions[priority]
             for extension in extensions_same_prio.values():
                 try:
                     retval = extension.create_prefix_script(
-                        Path(install_base), ordered_pkg_names, merge_install)
+                        Path(install_base), merge_install)
                     assert retval is None, \
                         'create_prefix_script() should return None'
                 except Exception as e:

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -32,7 +32,7 @@ class Extension2(ShellExtensionPoint):
 def test_extension_interface():
     extension = Extension1()
     with pytest.raises(NotImplementedError):
-        extension.create_prefix_script(None, None, None)
+        extension.create_prefix_script(None, None)
     with pytest.raises(NotImplementedError):
         extension.create_package_script(None, None, None)
     with pytest.raises(NotImplementedError):

--- a/test/test_shell_bat.py
+++ b/test/test_shell_bat.py
@@ -36,11 +36,8 @@ def _test_extension(prefix_path):
     extension = BatShell()
 
     # create_prefix_script
-    extension.create_prefix_script(prefix_path, ['pkgA', 'pkgB'], False)
+    extension.create_prefix_script(prefix_path, False)
     assert (prefix_path / 'local_setup.bat').exists()
-    content = (prefix_path / 'local_setup.bat').read_text()
-    assert 'pkgA' in content
-    assert 'pkgB' in content
 
     # create_package_script
     extension.create_package_script(

--- a/test/test_shell_sh.py
+++ b/test/test_shell_sh.py
@@ -36,11 +36,9 @@ def _test_extension(prefix_path):
     extension = ShShell()
 
     # create_prefix_script
-    extension.create_prefix_script(prefix_path, ['pkgA', 'pkgB'], False)
+    extension.create_prefix_script(prefix_path, False)
     assert (prefix_path / 'local_setup.sh').exists()
-    content = (prefix_path / 'local_setup.sh').read_text()
-    assert 'pkgA' in content
-    assert 'pkgB' in content
+    assert (prefix_path / '_local_setup_util.py').exists()
 
     # create_package_script
     extension.create_package_script(

--- a/test/test_shell_template_prefix_util.py
+++ b/test/test_shell_template_prefix_util.py
@@ -1,0 +1,94 @@
+# Copyright 2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from colcon_core.shell.template.prefix_util import get_packages
+from colcon_core.shell.template.prefix_util import main
+from colcon_core.shell.template.prefix_util import order_packages
+from colcon_core.shell.template.prefix_util import reduce_cycle_set
+from mock import patch
+import pytest
+
+
+def test_main(capsys):
+    with patch(
+        'colcon_core.shell.template.prefix_util.get_packages',
+        return_value={'pkgA': set()}
+    ):
+        main([])
+    out, err = capsys.readouterr()
+    assert out == 'pkgA\n'
+    assert not err
+
+
+def test_get_packages():
+    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
+        prefix_path = Path(prefix_path)
+
+        # mock packages in not merged install layout
+        subdirectory = 'share/colcon_core/packages'
+        for pkg_name in ('pkgA', 'pkgB'):
+            (prefix_path / pkg_name / subdirectory).mkdir(parents=True)
+            (prefix_path / pkg_name / subdirectory / pkg_name).write_text(
+                'depX')
+        (prefix_path / 'dummy_dir').mkdir()
+        (prefix_path / '.hidden_dir').mkdir()
+        (prefix_path / 'dummy_file').write_text('')
+
+        # mock packages in merged install layout
+        (prefix_path / subdirectory).mkdir(parents=True)
+        (prefix_path / subdirectory / 'pkgB').write_text('')
+        (prefix_path / subdirectory / 'pkgC').write_text(
+            os.pathsep.join(('pkgB', 'depC')))
+        (prefix_path / subdirectory / 'dummy_dir').mkdir()
+        (prefix_path / subdirectory / '.hidden_file').write_text('')
+
+        # check packages and dependencies in not merged install layout
+        packages = get_packages(prefix_path, False)
+        assert len(packages) == 2
+        assert 'pkgA' in packages
+        assert packages['pkgA'] == set()
+        assert 'pkgB' in packages
+        assert packages['pkgB'] == set()
+
+        # check packages and dependencies in not merged install layout
+        packages = get_packages(prefix_path, True)
+        assert len(packages) == 2
+        assert 'pkgB' in packages
+        assert packages['pkgB'] == set()
+        assert 'pkgC' in packages
+        assert packages['pkgC'] == {'pkgB'}
+
+
+def test_order_packages():
+    packages = {
+        'pkgA': {'pkgC'},
+        'pkgB': {},
+        'pkgC': {},
+    }
+    ordered = order_packages(packages)
+    assert ordered == ['pkgB', 'pkgC', 'pkgA']
+
+    packages = {
+        'pkgA': {'pkgB'},
+        'pkgB': {'pkgA'},
+        'pkgC': set(),
+    }
+    with pytest.raises(RuntimeError) as e:
+        ordered = order_packages(packages)
+    assert 'Circular dependency between:' in str(e.value)
+    assert 'pkgA' in str(e.value)
+    assert 'pkgB' in str(e.value)
+    assert 'pkgC' not in str(e.value)
+
+
+def test_reduce_cycle_set():
+    packages = {
+        'pkgA': {'pkgB'},
+        'pkgB': set(),
+    }
+    reduce_cycle_set(packages)
+    assert len(packages) == 0


### PR DESCRIPTION
Addresses #56.

Since the `pkg_names` are not necessary anymore in the `create_prefix_script` function of the `ShellExtensionPoint` I removed the argument from the signature. As a consequence I bumped the extension version accordingly (which is the first time) and its nice to see the extension point versioning mechanism working in action :smirk: