### PR TITLE
add pytest-runner as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
   pytest-cov
   pytest-repeat
   pytest-rerunfailures
+  pytest-runner
   setuptools
 packages = find:
 tests_require =

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [colcon-core]
-Depends3: python3-empy, python3-pytest, python3-pytest-cov, python3-setuptools
+Depends3: python3-empy, python3-pytest, python3-pytest-cov, python3-pytest-runner, python3-setuptools
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
This will address the problem with the Bouncy devel jobs not picking up the `pytest` tests. Basically without it `setup.py test` doesn't find any tests.

This requires `python3-pytest-runner` to be available in Ubuntu Xenial (on all other platforms it is available out-of-the-box). I tried installing the [Bionic Debian](https://launchpad.net/ubuntu/+archive/primary/+files/python3-pytest-runner_2.11.1-1_all.deb) in a Xenial docker which worked without a problem. @tfoote Can you please import this Debian into our bootstrap repo.