### PR TITLE
add separate --test-result-base argument

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -50,8 +50,11 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             'setup.py', 'pytest',
             'egg_info', '--egg-base', context.args.build_base,
         ]
+        junit_xml_path = Path(
+            context.args.test_result_base
+            if context.args.test_result_base
+            else context.args.build_base) / 'pytest.xml'
         # avoid using backslashes in the PYTEST_ADDOPTS env var on Windows
-        junit_xml_path = Path(context.args.build_base) / 'pytest.xml'
         args = [
             '--tb=short',
             '--junit-xml=' + str(PurePosixPath(*junit_xml_path.parts)),
@@ -124,6 +127,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
 
         # create dummy result in case the invocation fails early
         # and doesn't generate a result file at all
+        junit_xml_path.parent.mkdir(parents=True, exist_ok=True)
         junit_xml_path.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="{context.pkg.name}" tests="1" failures="1" time="0" errors="0" skip="0">
   <testcase classname="{context.pkg.name}" name="pytest.missing_result" status="run" time="0">

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -51,6 +51,9 @@ class BuildPackageArguments:
             self.install_base = os.path.join(
                 self.install_base, pkg.name)
         self.symlink_install = args.symlink_install
+        self.test_result_base = os.path.abspath(os.path.join(
+            os.getcwd(), args.test_result_base, pkg.name)) \
+            if args.test_result_base else None
 
         # set additional arguments from the command line or package metadata
         for dest in (additional_destinations or []):
@@ -147,6 +150,9 @@ class BuildVerb(VerbExtensionPoint):
             '--symlink-install',
             action='store_true',
             help='Use symlinks instead of copying files where possible')
+        parser.add_argument(
+            '--test-result-base',
+            help='The base path for all test results (default: --build-base)')
         add_executor_arguments(parser)
         add_event_handler_arguments(parser)
 

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -48,6 +48,9 @@ class TestPackageArguments:
         if not args.merge_install:
             self.install_base = os.path.join(
                 self.install_base, pkg.name)
+        self.test_result_base = os.path.abspath(os.path.join(
+            os.getcwd(), args.test_result_base, pkg.name)) \
+            if args.test_result_base else None
 
         # set additional arguments from the command line or package metadata
         for dest in (additional_destinations or []):
@@ -146,6 +149,9 @@ class TestVerb(VerbExtensionPoint):
             '--merge-install',
             action='store_true',
             help='Merge all install prefixes into a single location')
+        parser.add_argument(
+            '--test-result-base',
+            help='The base path for all test results (default: --build-base)')
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             '--retest-until-fail',


### PR DESCRIPTION
Allows to generate the test results in a different directory than the `build` directory.