### PR TITLE
add marker for install layout

### DIFF
--- a/colcon_core/verb/__init__.py
+++ b/colcon_core/verb/__init__.py
@@ -112,6 +112,11 @@ def check_and_mark_install_layout(install_base, *, merge_install):
                 'install directory, pick a different one or {change_option} '
                 "the '--merge-install' option.".format_map(locals()))
     else:
-        os.makedirs(install_base, exist_ok=True)
+        try:
+            os.makedirs(install_base, exist_ok=True)
+        except FileExistsError:
+            raise RuntimeError(
+                "The install base '{install_base}' is not a directory"
+                .format_map(locals()))
 
     marker_path.write_text(this_install_layout + '\n')

--- a/colcon_core/verb/__init__.py
+++ b/colcon_core/verb/__init__.py
@@ -85,3 +85,33 @@ def check_and_mark_build_tool(build_base, *, this_build_tool='colcon'):
         os.makedirs(build_base, exist_ok=True)
 
     marker_path.write_text(this_build_tool + '\n')
+
+
+def check_and_mark_install_layout(install_base, *, merge_install):
+    """
+    Check the marker file for the previous install layout, otherwise create it.
+
+    The marker filename is `.colcon_install_layout`.
+
+    :param str install_base: The install directory
+    :param bool merge_install: The flag if all packages share the same prefix
+    :raises RuntimeError: if the marker file contains a different install
+      layout
+    """
+    this_install_layout = 'merged' if merge_install else 'isolated'
+    marker_path = Path(install_base) / '.colcon_install_layout'
+    if marker_path.parent.is_dir():
+        if marker_path.is_file():
+            previous_install_layout = marker_path.read_text().rstrip()
+            if previous_install_layout == this_install_layout:
+                return
+            change_option = 'remove' if merge_install else 'add'
+            raise RuntimeError(
+                "The install directory '{install_base}' was created with the "
+                "layout '{previous_install_layout}'. Please remove the "
+                'install directory, pick a different one or {change_option} '
+                "the '--merge-install' option.".format_map(locals()))
+    else:
+        os.makedirs(install_base, exist_ok=True)
+
+    marker_path.write_text(this_install_layout + '\n')

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -24,6 +24,7 @@ from colcon_core.task import add_task_arguments
 from colcon_core.task import get_task_extension
 from colcon_core.task import TaskContext
 from colcon_core.verb import check_and_mark_build_tool
+from colcon_core.verb import check_and_mark_install_layout
 from colcon_core.verb import logger
 from colcon_core.verb import VerbExtensionPoint
 
@@ -164,6 +165,9 @@ class BuildVerb(VerbExtensionPoint):
 
     def main(self, *, context):  # noqa: D102
         check_and_mark_build_tool(context.args.build_base)
+        check_and_mark_install_layout(
+            context.args.install_base,
+            merge_install=context.args.merge_install)
 
         self._create_paths(context.args)
 

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -21,6 +21,7 @@ from colcon_core.task import add_task_arguments
 from colcon_core.task import get_task_extension
 from colcon_core.task import TaskContext
 from colcon_core.verb import check_and_mark_build_tool
+from colcon_core.verb import check_and_mark_install_layout
 from colcon_core.verb import VerbExtensionPoint
 
 logger = colcon_logger.getChild(__name__)
@@ -181,6 +182,9 @@ class TestVerb(VerbExtensionPoint):
 
     def main(self, *, context):  # noqa: D102
         check_and_mark_build_tool(context.args.build_base)
+        check_and_mark_install_layout(
+            context.args.install_base,
+            merge_install=context.args.merge_install)
 
         decorators = get_packages(
             context.args,

--- a/test/test_verb.py
+++ b/test/test_verb.py
@@ -94,3 +94,7 @@ def test_check_and_mark_install_layout():
         # existing marker with different content
         with pytest.raises(RuntimeError):
             check_and_mark_install_layout(str(path), merge_install=False)
+
+        # install base which is a file
+        with pytest.raises(RuntimeError):
+            check_and_mark_install_layout(str(marker_path), merge_install=True)


### PR DESCRIPTION
Adding this meta information to the install prefix for #76.

With this change the tool actually prints an error when trying to switch the layout of an existing install prefix.