### PR TITLE
rename package index directory

### DIFF
--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -179,4 +179,4 @@ def get_relative_package_index_path():
     :rtype: Path
     """
     # the value is also being hard coded in shell/template/prefix_util.py
-    return Path('share', 'colcon_core', 'packages')
+    return Path('share', 'colcon-core', 'packages')

--- a/colcon_core/shell/template/prefix_util.py
+++ b/colcon_core/shell/template/prefix_util.py
@@ -36,7 +36,7 @@ def get_packages(prefix_path, merged_install):
     packages = {}
     # since importing colcon_core isn't feasible here the following constant
     # must match colcon_core.location.get_relative_package_index_path()
-    subdirectory = 'share/colcon_core/packages'
+    subdirectory = 'share/colcon-core/packages'
     if merged_install:
         # find all files in the subdirectory
         for p in (prefix_path / subdirectory).iterdir():


### PR DESCRIPTION
The directory name should match the package name - hence a `-` instead of a `_`.