### PR TITLE
expose file extensions covered by a shell extension

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -55,6 +55,18 @@ class ShellExtensionPoint:
     """
     PRIORITY = 100
 
+    def get_file_extensions(self):
+        """
+        Get the file extensions provided by this extension.
+
+        By default the extension name will be returned.
+        The method is intended to be overridden in a subclass.
+
+        :returns: the file extensions
+        :rtype: tuple
+        """
+        return (self.SHELL_NAME, )
+
     def create_prefix_script(self, prefix_path, merge_install):
         """
         Create a script in the install prefix path.

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -50,7 +50,7 @@ class ShellExtensionPoint:
     `sh` shell extension to setup environment variables and only contributes
     additional information like completion.
 
-    All "non-primiry" shell extensions must use a priority equal to or lower
+    All "non-primary" shell extensions must use a priority equal to or lower
     than the default.
     """
     PRIORITY = 100


### PR DESCRIPTION
Making the file extensions for each shell extension available enables colcon/colcon-ros#29 which avoids hard coding those file extensions.