### PR TITLE
setuptools min version

### DIFF
--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -7,7 +7,20 @@ from colcon_core.package_identification import logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
-from setuptools.config import read_configuration
+try:
+    from setuptools.config import read_configuration
+except ImportError as e:
+    from pkg_resources import get_distribution
+    from pkg_resources import parse_version
+    setuptools_version = get_distribution('setuptools').version
+    minimum_version = '30.3.0'
+    if parse_version(setuptools_version) < parse_version(minimum_version):
+        e.msg += ', ' \
+            "'setuptools' needs to be at least version {minimum_version}, if" \
+            ' a newer version is not available from the package manager use ' \
+            "'pip3 install -U setuptools' to update to the latest version" \
+            .format_map(locals())
+    raise
 
 
 class PythonPackageIdentification(PackageIdentificationExtensionPoint):

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
   pytest-repeat
   pytest-rerunfailures
   pytest-runner
-  setuptools
+  setuptools>=30.3.0
 packages = find:
 tests_require =
   flake8


### PR DESCRIPTION
Fixes #90.

The first commit declares the minimum version of setuptools required. This only works when using `pip` to install the package. The version dependency can't be specified in the `stdeb.cfg` file since some supported platforms like Ubuntu Xenial don't provide a new enough Debian package of `setuptools`.

The second commit will catch the case where the available `setuptools` version is too old and provide a custom error message describing the problem as well as a way to update the package via `pip`.