### PR TITLE
add function to format duration as hours, minutes and seconds

### DIFF
--- a/colcon_core/event_handler/__init__.py
+++ b/colcon_core/event_handler/__init__.py
@@ -116,6 +116,10 @@ def format_duration(seconds, *, fixed_decimal_points=None):
     :returns: The string representation of the duration
     :rtype: str
     """
+    if seconds < 0.0:
+        raise ValueError(
+            "The duration '{seconds}' must be a non-negative number"
+            .format_map(locals()))
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
 

--- a/colcon_core/event_handler/console_start_end.py
+++ b/colcon_core/event_handler/console_start_end.py
@@ -8,6 +8,7 @@ from colcon_core.event.job import JobEnded
 from colcon_core.event.job import JobStarted
 from colcon_core.event.test import TestFailure
 from colcon_core.event_handler import EventHandlerExtensionPoint
+from colcon_core.event_handler import format_duration
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.subprocess import SIGINT_RESULT
 
@@ -43,10 +44,10 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
             self._with_test_failures.add(job)
 
         elif isinstance(data, JobEnded):
-            duration = time.time() - self._start_times[data.identifier]
-
             if not data.rc:
-                msg = 'Finished <<< {data.identifier} [{duration:.2f}s]' \
+                duration = time.time() - self._start_times[data.identifier]
+                duration_string = format_duration(duration)
+                msg = 'Finished <<< {data.identifier} [{duration_string}]' \
                     .format_map(locals())
                 job = event[1]
                 if job in self._with_test_failures:

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -57,6 +57,7 @@ sigint
 stderr
 stdout
 str
+stringify
 subparser
 subparsers
 symlink

--- a/test/test_event_handler.py
+++ b/test/test_event_handler.py
@@ -111,3 +111,6 @@ def test_format_duration():
     assert format_duration(34.5, fixed_decimal_points=1) == '34.5s'
     assert format_duration(3599.4, fixed_decimal_points=1) == '59min 59.4s'
     assert format_duration(4984.5, fixed_decimal_points=1) == '1h 23min 4.5s'
+    # raise for negative parameter
+    with pytest.raises(ValueError):
+        format_duration(-1.0)

--- a/test/test_event_handler.py
+++ b/test/test_event_handler.py
@@ -6,6 +6,7 @@ import argparse
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.event_handler import apply_event_handler_arguments
 from colcon_core.event_handler import EventHandlerExtensionPoint
+from colcon_core.event_handler import format_duration
 from colcon_core.event_handler import get_event_handler_extensions
 from mock import Mock
 import pytest
@@ -76,3 +77,37 @@ def test_apply_event_handler_arguments():
     assert extensions['extension1'].enabled is True
     assert extensions['extension2'].enabled is False
     assert extensions['extension3'].enabled is None
+
+
+def test_format_duration():
+    # seconds below 10 with two decimal points
+    assert format_duration(0) == '0.00s'
+    assert format_duration(0.001) == '0.00s'
+    assert format_duration(0.004999) == '0.00s'
+    assert format_duration(0.005) == '0.01s'
+    assert format_duration(9.99) == '9.99s'
+    assert format_duration(9.994999) == '9.99s'
+    assert format_duration(9.995) == '9.99s'  # floating point imprecision
+    # seconds between 10 and 60 with one decimal points
+    assert format_duration(9.995001) == '10.0s'
+    assert format_duration(10) == '10.0s'
+    assert format_duration(59.94) == '59.9s'
+    # seconds above one minute with no decimal points
+    assert format_duration(59.95) == '1min 0s'
+    assert format_duration(83.45) == '1min 23s'
+    assert format_duration(119.49) == '1min 59s'
+    assert format_duration(119.5) == '2min 0s'
+    assert format_duration(3599.4) == '59min 59s'
+    # seconds above one hour with no decimal points
+    assert format_duration(3599.5) == '1h 0min 0s'
+    assert format_duration(5025.123) == '1h 23min 45s'
+    assert format_duration(3599999) == '999h 59min 59s'
+    # zero fixed decimal point
+    assert format_duration(1.5, fixed_decimal_points=0) == '2s'
+    assert format_duration(12.345, fixed_decimal_points=0) == '12s'
+    # one fixed decimal points
+    assert format_duration(1.5, fixed_decimal_points=1) == '1.5s'
+    assert format_duration(12.345, fixed_decimal_points=1) == '12.3s'
+    assert format_duration(34.5, fixed_decimal_points=1) == '34.5s'
+    assert format_duration(3599.4, fixed_decimal_points=1) == '59min 59.4s'
+    assert format_duration(4984.5, fixed_decimal_points=1) == '1h 23min 4.5s'


### PR DESCRIPTION
Instead of just printing the seconds (with two decimals) for it with minutes and potentially hours. Also use two, one or no decimals for the seconds depending on how large the duration is.