### PR TITLE
Change PackageDescriptor.dependencies to DependencyDescriptors

### DIFF
--- a/colcon_core/dependency_descriptor.py
+++ b/colcon_core/dependency_descriptor.py
@@ -1,0 +1,37 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+
+class DependencyDescriptor:
+    """
+    A descriptor for a package dependency.
+
+    A dependency is identified by its name.
+
+    The 'metadata' dictionary can store any additional information.
+    """
+
+    __slots__ = (
+        '_name',
+        'metadata'
+    )
+
+    def __init__(self, name, *, metadata=None):
+        """
+        Descriptor for a package dependency.
+
+        :param str name: Name of the declared dependency
+        :param dict metadata: Any metadata associated with
+        the dependency
+        """
+        self._name = name
+        self.metadata = metadata if metadata is not None else {}
+
+    @property
+    def name(self):
+        """Name of the dependency."""
+        return self._name
+
+    def __str__(self):  # noqa: D105
+        return '{' + ', '.join(
+            ['%s: %s' % (s, getattr(self, s)) for s in self.__slots__]) + '}'

--- a/colcon_core/dependency_descriptor.py
+++ b/colcon_core/dependency_descriptor.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0
 
 
-class DependencyDescriptor:
+class DependencyDescriptor(str):
     """
     A descriptor for a package dependency.
 
-    A dependency is identified by its name.
+    A dependency is identified by its name. This subclasses str for backwards
+    compatibility purposes.
 
     The 'metadata' dictionary can store any additional information.
     """
@@ -16,14 +17,20 @@ class DependencyDescriptor:
         'metadata'
     )
 
-    def __init__(self, name, *, metadata=None):
+    def __new__(cls, name, metadata=None):
         """
         Descriptor for a package dependency.
 
-        :param str name: Name of the declared dependency
+        :param str value: Name of the declared dependency
         :param dict metadata: Any metadata associated with
         the dependency
         """
+        name_copy = str(name)
+        obj = str.__new__(cls, name_copy)
+        return obj
+
+    def __init__(self, name, metadata=None):  # noqa: D107
+        super(DependencyDescriptor, self).__init__()
         self._name = name
         self.metadata = metadata if metadata is not None else {}
 
@@ -32,9 +39,15 @@ class DependencyDescriptor:
         """Name of the dependency."""
         return self._name
 
-    def __str__(self):  # noqa: D105
-        return '{' + ', '.join(
-            ['%s: %s' % (s, getattr(self, s)) for s in self.__slots__]) + '}'
+    def __eq__(self, other):  # noqa: D105
+        if isinstance(other, DependencyDescriptor):
+            return self._name == other._name and \
+                self.metadata == other.metadata
+        else:
+            return self._name == other
+
+    def __hash__(self):  # noqa: D105
+        return hash(self._name)
 
 
 def dependency_name(dependency):

--- a/colcon_core/dependency_descriptor.py
+++ b/colcon_core/dependency_descriptor.py
@@ -35,3 +35,24 @@ class DependencyDescriptor:
     def __str__(self):  # noqa: D105
         return '{' + ', '.join(
             ['%s: %s' % (s, getattr(self, s)) for s in self.__slots__]) + '}'
+
+
+def dependency_name(dependency):
+    """
+    Get the name of the dependency.
+
+    This should be used to maintain backwards compatibility with extensions
+    that treat PackageDescriptor.dependencies as a list of strings
+    instead of a list of DependencyDescriptor
+
+    :param dependency: string or DependencyDescriptor
+    :return: name of the dependency
+    :rtype: str
+    """
+    if isinstance(dependency, DependencyDescriptor):
+        return dependency.name
+    elif isinstance(dependency, str):
+        return dependency
+    else:
+        raise RuntimeError(
+            'Passed in object is not a str or DependencyDescriptor')

--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import traceback
 
+from colcon_core.dependency_descriptor import dependency_name
 from colcon_core.location import get_relative_package_index_path
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import instantiate_extensions
@@ -126,7 +127,8 @@ def create_environment_scripts(
     # create file containing the runtime dependencies
     path = prefix_path / get_relative_package_index_path() / pkg.name
     path.parent.mkdir(parents=True, exist_ok=True)
-    dependencies = [d.name for d in pkg.dependencies.get('run', set())]
+    dependencies = [
+        dependency_name(d) for d in pkg.dependencies.get('run', set())]
     path.write_text(os.pathsep.join(sorted(dependencies)))
 
 

--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -126,8 +126,8 @@ def create_environment_scripts(
     # create file containing the runtime dependencies
     path = prefix_path / get_relative_package_index_path() / pkg.name
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        os.pathsep.join(sorted(pkg.dependencies.get('run', set()))))
+    dependencies = [d.name for d in pkg.dependencies.get('run', set())]
+    path.write_text(os.pathsep.join(sorted(dependencies)))
 
 
 def create_environment_hooks(prefix_path, pkg_name):

--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -16,7 +16,7 @@ class PackageDescriptor:
     * the 'type' which must be a non-empty string
     * the 'name' which must be a non-empty string
 
-    'dependencies' are grouped by their category as DependencyDescriptor
+    'dependencies' are grouped by their category as DependencyDescriptor or str
 
     Each item in 'hooks' must be a relative path in the installation space.
 
@@ -61,7 +61,7 @@ class PackageDescriptor:
 
         :param Iterable[str] categories: The names of the specific categories
         :returns: The dependencies for the passed in category or all
-        :rtype: set[DependencyDescriptor]
+        :rtype: set[DependencyDescriptor, str]
         :raises AssertionError: if the package name is listed as a dependency
         """
         dependencies = set()
@@ -91,7 +91,7 @@ class PackageDescriptor:
         :param Iterable[str] recursive_categories: The names of the recursive
           categories
         :returns: The recursive dependencies of self
-        :rtype: set[DependencyDescriptor]
+        :rtype: set[DependencyDescriptor, str]
         :raises AssertionError: if a package lists itself as a dependency
         """
         queue = self.get_dependencies(categories=direct_categories)

--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -4,6 +4,8 @@
 from collections import defaultdict
 from pathlib import Path
 
+from colcon_core.dependency_descriptor import dependency_name
+
 
 class PackageDescriptor:
     """
@@ -67,7 +69,7 @@ class PackageDescriptor:
             categories = self.dependencies.keys()
         for category in sorted(categories):
             dependencies |= self.dependencies[category]
-        dependency_names = {d.name for d in dependencies}
+        dependency_names = {dependency_name(d) for d in dependencies}
         assert self.name not in dependency_names, \
             "The package '{self.name}' has a dependency with the same name" \
             .format_map(locals())
@@ -97,9 +99,9 @@ class PackageDescriptor:
         while queue:
             # pick one dependency from the queue
             dependency = queue.pop()
-            name = dependency.name
+            name = dependency_name(dependency)
             # ignore redundant dependencies
-            if name in {dep.name for dep in dependencies}:
+            if name in {dependency_name(dep) for dep in dependencies}:
                 continue
             # ignore circular dependencies
             if name == self.name:

--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -3,6 +3,7 @@
 
 import re
 
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_identification import logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
@@ -100,5 +101,5 @@ def extract_dependencies(options):
             # remove environmental markers (separated by semicolons)
             # and version specifiers (separated by comparison operators)
             name = re.split(r';|<|>|<=|>=|==|!=', dep)[0].rstrip()
-            dependencies[dependency_type].add(name)
+            dependencies[dependency_type].add(DependencyDescriptor(name))
     return dependencies

--- a/colcon_core/topological_order.py
+++ b/colcon_core/topological_order.py
@@ -27,10 +27,11 @@ def topological_order_packages(
             descriptors,
             direct_categories=direct_categories,
             recursive_categories=recursive_categories)
+        rec_dep_names = {d.name for d in rec_deps}
         d = _PackageDependencies(
             descriptor=descriptor,
-            recursive_dependencies=rec_deps,
-            remaining_dependencies=copy.deepcopy(rec_deps),
+            recursive_dependencies=rec_dep_names,
+            remaining_dependencies=copy.deepcopy(rec_dep_names),
         )
         queued.add(d)
 

--- a/colcon_core/topological_order.py
+++ b/colcon_core/topological_order.py
@@ -4,6 +4,7 @@
 from collections import OrderedDict
 import copy
 
+from colcon_core.dependency_descriptor import dependency_name
 from colcon_core.package_decorator import PackageDecorator
 
 
@@ -27,7 +28,7 @@ def topological_order_packages(
             descriptors,
             direct_categories=direct_categories,
             recursive_categories=recursive_categories)
-        rec_dep_names = {d.name for d in rec_deps}
+        rec_dep_names = {dependency_name(d) for d in rec_deps}
         d = _PackageDependencies(
             descriptor=descriptor,
             recursive_dependencies=rec_dep_names,

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -19,6 +19,7 @@ ctrl
 cwd
 decodable
 decoree
+dependencydescriptor
 desc
 descs
 dict

--- a/test/test_dependency_descriptor.py
+++ b/test/test_dependency_descriptor.py
@@ -3,7 +3,8 @@
 
 import copy
 
-from colcon_core.dependency_descriptor import DependencyDescriptor
+from colcon_core.dependency_descriptor import dependency_name, \
+    DependencyDescriptor
 
 
 def test_constructor():
@@ -37,7 +38,7 @@ def test_str():
 
 def check_dependencies(actual, expected):
     """
-    Check that all of the expected names are in actual
+    Check that all of the expected names are in actual.
 
     :param actual: Set of DependencyDescriptor
     :param expected: List of str names
@@ -50,7 +51,7 @@ def check_dependencies(actual, expected):
 
     for name in expected:
         descriptor = next(iter(
-            [d for d in deps if d.name == name]), None)
+            [d for d in deps if dependency_name(d) == name]), None)
         if descriptor is None:
             return False
         deps.remove(descriptor)

--- a/test/test_dependency_descriptor.py
+++ b/test/test_dependency_descriptor.py
@@ -1,0 +1,58 @@
+# Copyright 2016-2018 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import copy
+
+from colcon_core.dependency_descriptor import DependencyDescriptor
+
+
+def test_constructor():
+    name = 'ReallyCoolPackage'
+    descriptor = DependencyDescriptor(name)
+    assert descriptor.name == name
+    assert len(descriptor.metadata.keys()) == 0
+
+
+def test_metadata():
+    metadata = {
+        'foo': 'bar'
+    }
+    descriptor = DependencyDescriptor('CoolStuff',
+                                      metadata=metadata)
+    assert descriptor.metadata == metadata
+
+
+def test_str():
+    d = DependencyDescriptor('Package1')
+    d.metadata['key'] = 'value'
+    s = str(d)
+    assert s.startswith('{')
+    assert s.endswith('}')
+    assert 'name: ' in s
+    assert 'Package1' in s
+    assert 'metadata: ' in s
+    assert 'key' in s
+    assert 'value' in s
+
+
+def check_dependencies(actual, expected):
+    """
+    Check that all of the expected names are in actual
+
+    :param actual: Set of DependencyDescriptor
+    :param expected: List of str names
+    :return: True if all expected names are in actual
+    """
+    if len(actual) != len(expected):
+        return False
+
+    deps = copy.copy(actual)
+
+    for name in expected:
+        descriptor = next(iter(
+            [d for d in deps if d.name == name]), None)
+        if descriptor is None:
+            return False
+        deps.remove(descriptor)
+    assert len(deps) == 0
+    return True

--- a/test/test_dependency_descriptor.py
+++ b/test/test_dependency_descriptor.py
@@ -27,13 +27,18 @@ def test_str():
     d = DependencyDescriptor('Package1')
     d.metadata['key'] = 'value'
     s = str(d)
-    assert s.startswith('{')
-    assert s.endswith('}')
-    assert 'name: ' in s
-    assert 'Package1' in s
-    assert 'metadata: ' in s
-    assert 'key' in s
-    assert 'value' in s
+    assert s == 'Package1'
+
+
+def test_eq():
+    d = DependencyDescriptor('foo')
+    assert 'foo' == d
+    assert d == 'foo'
+
+
+def test_hash():
+    d = DependencyDescriptor('hashme')
+    assert d.__hash__() == hash('hashme')
 
 
 def check_dependencies(actual, expected):

--- a/test/test_package_augmentation.py
+++ b/test/test_package_augmentation.py
@@ -118,7 +118,7 @@ def test_update_descriptor():
     update_descriptor(desc, data)
     assert len(desc.dependencies) == 2
     assert 'build' in desc.dependencies.keys()
-    assert check_dependencies(desc.dependencies['build'], ['b1','b2'])
+    assert check_dependencies(desc.dependencies['build'], ['b1', 'b2'])
     assert 'test' in desc.dependencies.keys()
     assert check_dependencies(desc.dependencies['test'], ['t1'])
 

--- a/test/test_package_decorator.py
+++ b/test/test_package_decorator.py
@@ -1,9 +1,9 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_decorator import add_recursive_dependencies
 from colcon_core.package_decorator import get_decorators
-from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_decorator import PackageDecorator
 from colcon_core.package_descriptor import PackageDescriptor
 from mock import Mock
@@ -31,7 +31,7 @@ def test_get_decorators():
 def test_add_recursive_dependencies():
     d = PackageDescriptor('/some/path')
     d.name = 'A'
-    d.dependencies['build'].add(DependencyDescriptor('B'))
+    d.dependencies['build'].add('B')
     d.dependencies['build'].add(DependencyDescriptor('c'))
     d.dependencies['run'].add(DependencyDescriptor('D'))
     d.dependencies['test'].add(DependencyDescriptor('e'))
@@ -58,4 +58,5 @@ def test_add_recursive_dependencies():
     assert decos[1].recursive_dependencies is not None
     assert decos[2].recursive_dependencies is not None
     assert decos[3].recursive_dependencies is not None
-    assert check_dependencies(decos[0].recursive_dependencies, ['B', 'D', 'G'])
+    assert check_dependencies(
+        decos[0].recursive_dependencies, ['B', 'D', 'G'])

--- a/test/test_package_decorator.py
+++ b/test/test_package_decorator.py
@@ -3,9 +3,12 @@
 
 from colcon_core.package_decorator import add_recursive_dependencies
 from colcon_core.package_decorator import get_decorators
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_decorator import PackageDecorator
 from colcon_core.package_descriptor import PackageDescriptor
 from mock import Mock
+
+from .test_dependency_descriptor import check_dependencies
 
 
 def test_constructor():
@@ -28,23 +31,23 @@ def test_get_decorators():
 def test_add_recursive_dependencies():
     d = PackageDescriptor('/some/path')
     d.name = 'A'
-    d.dependencies['build'].add('B')
-    d.dependencies['build'].add('c')
-    d.dependencies['run'].add('D')
-    d.dependencies['test'].add('e')
+    d.dependencies['build'].add(DependencyDescriptor('B'))
+    d.dependencies['build'].add(DependencyDescriptor('c'))
+    d.dependencies['run'].add(DependencyDescriptor('D'))
+    d.dependencies['test'].add(DependencyDescriptor('e'))
 
     d1 = PackageDescriptor('/other/path')
     d1.name = 'B'
-    d1.dependencies['build'].add('f')
-    d1.dependencies['run'].add('G')
+    d1.dependencies['build'].add(DependencyDescriptor('f'))
+    d1.dependencies['run'].add(DependencyDescriptor('G'))
 
     d2 = PackageDescriptor('/other/path')
     d2.name = 'D'
-    d2.dependencies['run'].add('h')
+    d2.dependencies['run'].add(DependencyDescriptor('h'))
 
     d3 = PackageDescriptor('/another/path')
     d3.name = 'G'
-    d3.dependencies['build'].add('i')
+    d3.dependencies['build'].add(DependencyDescriptor('i'))
 
     decos = get_decorators([d, d1, d2, d3])
     add_recursive_dependencies(
@@ -55,4 +58,4 @@ def test_add_recursive_dependencies():
     assert decos[1].recursive_dependencies is not None
     assert decos[2].recursive_dependencies is not None
     assert decos[3].recursive_dependencies is not None
-    assert decos[0].recursive_dependencies == {'B', 'D', 'G'}
+    assert check_dependencies(decos[0].recursive_dependencies, ['B', 'D', 'G'])

--- a/test/test_package_descriptor.py
+++ b/test/test_package_descriptor.py
@@ -36,7 +36,7 @@ def test_identifies_package():
 def test_get_dependencies():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'self'
-    d1.dependencies['build'].add(DependencyDescriptor('build-depend'))
+    d1.dependencies['build'].add('build-depend')
     d1.dependencies['build'].add(DependencyDescriptor('depend'))
     d1.dependencies['run'].add(DependencyDescriptor('run-depend'))
     d1.dependencies['run'].add(DependencyDescriptor('depend'))
@@ -64,7 +64,7 @@ def test_get_recursive_dependencies():
     d1.name = 'B'
     d1.dependencies['build'].add(DependencyDescriptor('e'))
     d1.dependencies['run'].add(DependencyDescriptor('F'))
-    d1.dependencies['test'].add(DependencyDescriptor('G'))
+    d1.dependencies['test'].add('G')
 
     d2 = PackageDescriptor('/another/path')
     d2.name = 'd'

--- a/test/test_package_descriptor.py
+++ b/test/test_package_descriptor.py
@@ -37,12 +37,11 @@ def test_get_dependencies():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'self'
     d1.dependencies['build'].add('build-depend')
-    d1.dependencies['build'].add(DependencyDescriptor('depend'))
+    d1.dependencies['build'].add('depend')
     d1.dependencies['run'].add(DependencyDescriptor('run-depend'))
     d1.dependencies['run'].add(DependencyDescriptor('depend'))
     assert check_dependencies(d1.get_dependencies(),
-                              ['build-depend', 'run-depend', 'depend',
-                               'depend'])
+                              ['build-depend', 'run-depend', 'depend'])
 
     d1.dependencies['test'].add(DependencyDescriptor('self'))
     assert check_dependencies(d1.get_dependencies(categories=('build', )),

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -9,6 +9,8 @@ from colcon_core.package_identification.python \
     import PythonPackageIdentification
 import pytest
 
+from .test_dependency_descriptor import check_dependencies
+
 
 def test_identify():
     extension = PythonPackageIdentification()
@@ -63,9 +65,11 @@ def test_identify():
         assert desc.name == 'other-name'
         assert desc.type == 'python'
         assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
-        assert desc.dependencies['build'] == {'build', 'build-windows'}
-        assert desc.dependencies['run'] == {'runA', 'runB'}
-        assert desc.dependencies['test'] == {'test'}
+        assert check_dependencies(desc.dependencies['build'],
+                                  ['build', 'build-windows'])
+        assert check_dependencies(desc.dependencies['run'],
+                                  ['runA', 'runB'])
+        assert check_dependencies(desc.dependencies['test'], ['test'])
 
         assert callable(desc.metadata['get_python_setup_options'])
         options = desc.metadata['get_python_setup_options'](None)

--- a/test/test_topological_order.py
+++ b/test/test_topological_order.py
@@ -10,7 +10,7 @@ import pytest
 def test_topological_order_packages():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'a'
-    d1.dependencies['build'].add(DependencyDescriptor('c'))
+    d1.dependencies['build'].add('c')
     d2 = PackageDescriptor('/other/path')
     d2.name = 'b'
     d2.dependencies['run'].add(DependencyDescriptor('c'))
@@ -46,7 +46,7 @@ def test_topological_order_packages():
 def test_topological_order_packages_with_circular_dependency():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'one'
-    d1.dependencies['run'].add(DependencyDescriptor('two'))
+    d1.dependencies['run'].add('two')
 
     d2 = PackageDescriptor('/other/path')
     d2.name = 'two'

--- a/test/test_topological_order.py
+++ b/test/test_topological_order.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.topological_order import topological_order_packages
 import pytest
@@ -9,23 +10,23 @@ import pytest
 def test_topological_order_packages():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'a'
-    d1.dependencies['build'].add('c')
+    d1.dependencies['build'].add(DependencyDescriptor('c'))
     d2 = PackageDescriptor('/other/path')
     d2.name = 'b'
-    d2.dependencies['run'].add('c')
+    d2.dependencies['run'].add(DependencyDescriptor('c'))
 
     d3 = PackageDescriptor('/another/path')
     d3.name = 'c'
-    d3.dependencies['build'].add('e')
-    d3.dependencies['run'].add('f')
-    d3.dependencies['test'].add('d')
+    d3.dependencies['build'].add(DependencyDescriptor('e'))
+    d3.dependencies['run'].add(DependencyDescriptor('f'))
+    d3.dependencies['test'].add(DependencyDescriptor('d'))
 
     d4 = PackageDescriptor('/yet-another/path')
     d4.name = 'd'
-    d4.dependencies['run'].add('f')
+    d4.dependencies['run'].add(DependencyDescriptor('f'))
     d5 = PackageDescriptor('/more/path')
     d5.name = 'e'
-    d5.dependencies['run'].add('f')
+    d5.dependencies['run'].add(DependencyDescriptor('f'))
 
     d6 = PackageDescriptor('/yet-more/path')
     d6.name = 'f'
@@ -45,23 +46,23 @@ def test_topological_order_packages():
 def test_topological_order_packages_with_circular_dependency():
     d1 = PackageDescriptor('/some/path')
     d1.name = 'one'
-    d1.dependencies['run'].add('two')
+    d1.dependencies['run'].add(DependencyDescriptor('two'))
 
     d2 = PackageDescriptor('/other/path')
     d2.name = 'two'
-    d2.dependencies['run'].add('three')
+    d2.dependencies['run'].add(DependencyDescriptor('three'))
 
     d3 = PackageDescriptor('/another/path')
     d3.name = 'three'
-    d3.dependencies['run'].add('one')
-    d3.dependencies['run'].add('six')
+    d3.dependencies['run'].add(DependencyDescriptor('one'))
+    d3.dependencies['run'].add(DependencyDescriptor('six'))
 
     d4 = PackageDescriptor('/yet-another/path')
     d4.name = 'four'
 
     d5 = PackageDescriptor('/more/path')
     d5.name = 'five'
-    d5.dependencies['run'].add('four')
+    d5.dependencies['run'].add(DependencyDescriptor('four'))
 
     d6 = PackageDescriptor('/yet-more/path')
     d6.name = 'six'


### PR DESCRIPTION
This is for #106. 

I left some TODO in the code with questions. I think I caught all the usages in colcon_core. Anything using TaskContext.dependencies should be correct because that object is created in build.py/test.py where I have updated the usage of PackageDescriptor.dependencies.

I tested this with my updated colcon-ros in a simple ROS workspace. Do you have some test workspaces I can run this on to verify correctness? I don't have a python workspace to test against.