### PR TITLE
update log.warn (deprecated) to log.warning

### DIFF
--- a/colcon_core/logging.py
+++ b/colcon_core/logging.py
@@ -32,7 +32,7 @@ def set_logger_level_from_env(logger, env_name):
         try:
             numeric_log_level = get_numeric_log_level(log_level)
         except ValueError as e:
-            logger.warn(
+            logger.warning(
                 "environment variable '{env_name}' has unsupported value "
                 "'{log_level}', {e}".format_map(locals()))
         else:

--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -216,7 +216,7 @@ def update_metadata(desc, key, value):
         return
 
     if type(old_value) != type(value):
-        logger.warn(
+        logger.warning(
             "update package '{desc.name}' metadata '{key}' from value "
             "'{old_value}' to '{value}'".format_map(locals()))
 

--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -172,7 +172,7 @@ def discover_packages(
     if discovery_extensions is None:
         discovery_extensions = get_package_discovery_extensions()
     if not discovery_extensions:
-        logger.warn('No package discovery extensions found')
+        logger.warning('No package discovery extensions found')
         return set()
 
     # use only the discovery extensions which have parameters if any

--- a/colcon_core/package_identification/__init__.py
+++ b/colcon_core/package_identification/__init__.py
@@ -116,7 +116,7 @@ def identify(
         desc = result
 
     if getattr(desc, 'type', None) or getattr(desc, 'name', None):
-        logger.warn(
+        logger.warning(
             "package '{desc.path}' has type or name but is incomplete"
             .format_map(locals()))
     return None
@@ -151,7 +151,7 @@ def _identify(extensions_same_prio, desc):
 
     # multiple extensions populated the descriptor with different values
     if len(results) > 2:
-        logger.warn(
+        logger.warning(
             '_identify({desc.path}) has multiple matches and therefore is '
             'being ignored: '.format_map(locals()) +
             ', '.join(sorted(d.type for d in results if d.type is not None)))

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -276,7 +276,7 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
             parts = line.decode(encoding).split('=', 1)
         except UnicodeDecodeError as e:
             line_replaced = line.decode(encoding=encoding, errors='replace')
-            logger.warn(
+            logger.warning(
                 'Failed to decode line from the environment using the '
                 "encoding '{encoding}': {line_replaced}".format_map(locals()))
             continue
@@ -371,7 +371,7 @@ def get_colcon_prefix_path(*, skip=None):
             continue
         if not os.path.exists(path):
             if path not in _get_colcon_prefix_path_warnings:
-                logger.warn(
+                logger.warning(
                     "The path '{path}' in the environment variable "
                     "COLCON_PREFIX_PATH doesn't exist".format_map(locals()))
             _get_colcon_prefix_path_warnings.add(path)
@@ -415,7 +415,7 @@ def check_dependency_availability(dependencies, *, script_filename):
 
     # warn about using packages from the environment
     if env_packages:
-        logger.warn(
+        logger.warning(
             "The following packages are in the workspace but haven't been "
             'built:' +
             ''.join('\n- %s' % name for name in env_packages.keys()) +

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -130,7 +130,7 @@ class PythonBuildTask(TaskExtensionPoint):
         packages = setup_py_data['packages']
         for module_name in packages:
             if module_name in sys.modules:
-                logger.warn(
+                logger.warning(
                     "Switching to 'develop' for package '{pkg.name}' while it "
                     'is being used might result in import errors later'
                     .format_map(locals()))

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -64,7 +64,7 @@ class PythonTestTask(TaskExtensionPoint):
                 if matched:
                     break
             else:
-                logger.warn(
+                logger.warning(
                     "No Python Testing Step extension matched in '{args.path}'"
                     .format_map(locals()))
                 return

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -93,7 +93,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             try:
                 import pytest_repeat  # noqa: F401
             except ImportError:
-                logger.warn(
+                logger.warning(
                     "Ignored '--retest-until-fail' for package "
                     "'{context.pkg.name}' since the pytest extension 'repeat' "
                     'was not found'.format_map(locals()))
@@ -107,7 +107,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             try:
                 import pytest_rerunfailures  # noqa: F401
             except ImportError:
-                logger.warn(
+                logger.warning(
                     "Ignored '--retest-until-pass' for package "
                     "'{context.pkg.name}' since pytest extension "
                     "'rerunfailures' was not found".format_map(locals()))

--- a/colcon_core/task/python/test/setuppy_test.py
+++ b/colcon_core/task/python/test/setuppy_test.py
@@ -22,13 +22,13 @@ class SetuppyPythonTestingStep(PythonTestingStepExtensionPoint):
 
     async def step(self, context, env, setup_py_data):  # noqa: D102
         if context.args.retest_until_fail:
-            logger.warn(
+            logger.warning(
                 "Ignored '--retest-until-fail' for package "
                 "'{context.pkg.name}' since 'setup.py test' does not support "
                 'the usage'.format_map(locals()))
 
         if context.args.retest_until_pass:
-            logger.warn(
+            logger.warning(
                 "Ignored '--retest-until-pass' for package "
                 "'{context.pkg.name}' since 'setup.py test' does not support "
                 'the usage'.format_map(locals()))

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -208,7 +208,7 @@ class BuildVerb(VerbExtensionPoint):
             pkg = decorator.descriptor
             extension = get_task_extension('colcon_core.task.build', pkg.type)
             if not extension:
-                logger.warn(
+                logger.warning(
                     "No task extension to 'build' a '{pkg.type}' package"
                     .format_map(locals()))
                 continue

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -207,7 +207,7 @@ class TestVerb(VerbExtensionPoint):
             pkg = decorator.descriptor
             extension = get_task_extension('colcon_core.task.test', pkg.type)
             if not extension:
-                logger.warn(
+                logger.warning(
                     "No task extension to 'test' a '{pkg.type}' package"
                     .format_map(locals()))
                 continue

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,8 @@ exclude =
   test.*
 
 [tool:pytest]
+filterwarnings =
+    error
 junit_suite_name = colcon-core
 
 [options.entry_points]

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -21,9 +21,9 @@ def test_set_logger_level_from_env():
 
     # invalid value
     with EnvironmentContext(COLCON_TEST_LOGGER_LEVEL='invalid'):
-        logger.warn = Mock()
+        logger.warning = Mock()
         set_logger_level_from_env(logger, 'COLCON_TEST_LOGGER_LEVEL')
-        assert logger.warn.call_count == 1
+        assert logger.warning.call_count == 1
     assert logger.getEffectiveLevel() == default_level
 
     # valid value

--- a/test/test_package_augmentation.py
+++ b/test/test_package_augmentation.py
@@ -185,7 +185,7 @@ def test_update_metadata():
     assert 's' in desc.metadata.keys()
     assert desc.metadata['s'] == {1, 2, 3}
 
-    with patch('colcon_core.package_augmentation.logger.warn') as warn:
+    with patch('colcon_core.package_augmentation.logger.warning') as warn:
         update_metadata(desc, 's', 'different type')
     warn.assert_called_once_with(
         "update package 'name' metadata 's' from value '{1, 2, 3}' to "
@@ -194,7 +194,7 @@ def test_update_metadata():
     assert 's' in desc.metadata.keys()
     assert desc.metadata['s'] == 'different type'
 
-    with patch('colcon_core.package_augmentation.logger.warn') as warn:
+    with patch('colcon_core.package_augmentation.logger.warning') as warn:
         update_metadata(desc, 's', 'same type')
     assert warn.call_count == 0
     assert len(desc.metadata) == 3

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -89,7 +89,7 @@ def test_discover_packages():
         'colcon_core.package_discovery.get_package_discovery_extensions',
         return_value={},
     ) as get_extensions:
-        with patch('colcon_core.package_discovery.logger.warn') as warn:
+        with patch('colcon_core.package_discovery.logger.warning') as warn:
             descs = discover_packages(None, None)
     assert get_extensions.call_count == 1
     warn.assert_called_once_with('No package discovery extensions found')

--- a/test/test_package_identification.py
+++ b/test/test_package_identification.py
@@ -143,7 +143,9 @@ def test__identify():
         extensions = get_package_identification_extensions()[100]
         extensions['extension2'].identify = identify_name
         extensions['extension4'].identify = identify_type
-        with patch('colcon_core.package_identification.logger.warn') as warn:
+        with patch(
+            'colcon_core.package_identification.logger.warning'
+        ) as warn:
             desc = _identify(extensions, desc_path_only)
             assert desc is False
             # the raised exception is catched and results in a warn message

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -135,7 +135,7 @@ def test_get_environment_variables():
     async def check_output(cmd, **kwargs):
         return b'DECODE_ERROR=\x81\nNAME=value'
     with patch('colcon_core.shell.check_output', side_effect=check_output):
-        with patch('colcon_core.shell.logger.warn') as warn:
+        with patch('colcon_core.shell.logger.warning') as warn:
             coroutine = get_environment_variables(['not-used'], shell=False)
             env = run_until_complete(coroutine)
 
@@ -228,7 +228,7 @@ def test_get_colcon_prefix_path():
         with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
             [str(basepath), str(basepath / 'non-existing-sub')]
         )):
-            with patch('colcon_core.shell.logger.warn') as warn:
+            with patch('colcon_core.shell.logger.warning') as warn:
                 prefix_path = get_colcon_prefix_path()
             assert prefix_path == [str(basepath)]
             assert warn.call_count == 1
@@ -237,7 +237,7 @@ def test_get_colcon_prefix_path():
                 "non-existing-sub' in the environment variable "
                 "COLCON_PREFIX_PATH doesn't exist")
             # suppress duplicate warning
-            with patch('colcon_core.shell.logger.warn') as warn:
+            with patch('colcon_core.shell.logger.warning') as warn:
                 prefix_path = get_colcon_prefix_path()
             assert prefix_path == [str(basepath)]
             assert warn.call_count == 0
@@ -275,7 +275,7 @@ def test_check_dependency_availability():
             'colcon_core.shell.find_installed_packages_in_environment',
             side_effect=lambda: {'pkgA': prefix_path / 'env'}
         ):
-            with patch('colcon_core.shell.logger.warn') as warn:
+            with patch('colcon_core.shell.logger.warning') as warn:
                 check_dependency_availability(
                     dependencies, script_filename='package.ext')
         assert len(dependencies) == 0


### PR DESCRIPTION
Additionally set the `pytest` option `filterwarnings: error` so that future deprecation warning will result in a failing CI.

Once this is reviewed and merged I will open similar PRs in the other repos (but plan to go ahead and merge them without an explicit review if nobody objects since their changes will be the same).