### PR TITLE
Update setup.cfg patch to account for churn and whitespace

### DIFF
--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -5,17 +5,17 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 
 --- setup.cfg	2018-05-27 11:22:33.000000000 -0700
 +++ setup.cfg.patched	2018-05-27 11:22:33.000000000 -0700
-@@ -31,8 +31,11 @@
- 	EmPy
- 	pytest
- 	pytest-cov
--	pytest-repeat
--	pytest-rerunfailures
-+	# the following dependencies are not available from Debian
-+	# so listing them here but not installing them in the Debian package
-+	# would result in a runtime error by pkg_resources
-+	# pytest-repeat
-+	# pytest-rerunfailures
- 	pytest-runner
- 	setuptools>=30.3.0
+@@ -33,8 +33,11 @@
+   # even though they are only conditional
+   pytest
+   pytest-cov
+-  pytest-repeat
+-  pytest-rerunfailures
++  # the following dependencies are not available from Debian
++  # so listing them here but not installing them in the Debian package
++  # would result in a runtime error by pkg_resources
++  # pytest-repeat
++  # pytest-rerunfailures
+   pytest-runner
+   setuptools>=30.3.0
  packages = find:


### PR DESCRIPTION
The `setup.cfg.patch` appears to have been created against a version of `setup.cfg` that used tabs. There has also been a small amount of churn in `setup.cfg` since the patch was created.

The patch can currently be applied by ignoring whitespace and allowing fuzz, but it is easy enough to update the patch to get a clean application.