### PR TITLE
remove unused variable

### DIFF
--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -178,7 +178,7 @@ async def _async_check_call(
                 stdout if use_pty else None, stderr if use_pty else None))
         try:
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
-        except CancelledError as e:
+        except CancelledError:
             # finish the communication with the subprocess
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
             raise


### PR DESCRIPTION
Removing `e` since it isn't being used in the exception handling block.