### PR TITLE
Update python package identification to use DependencyDescriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - pip install -U setuptools
   # install_requires
-  - pip install -U EmPy distlib
+  - pip install -U distlib EmPy
   # tests_require
   - if [ "$TEST_SUITE" = "pytest" ]; then pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pyenchant pylint pytest pytest-cov; fi
   # colcon test needs pytest-cov and pytest-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
   - pip install -U setuptools
   # install_requires
-  - pip install -U EmPy
+  - pip install -U EmPy distlib
   # tests_require
   - if [ "$TEST_SUITE" = "pytest" ]; then pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pyenchant pylint pytest pytest-cov; fi
   # colcon test needs pytest-cov and pytest-runner

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   # install_requires
-  - "%PYTHON%\\python.exe -m pip install -U coloredlogs EmPy distlib"
+  - "%PYTHON%\\python.exe -m pip install -U coloredlogs distlib EmPy"
   # tests_require, except pyenchant, additionally mock
   - "%PYTHON%\\python.exe -m pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes mock pep8-naming pylint pytest pytest-cov"
   # for uploading the coverage information to codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   # install_requires
-  - "%PYTHON%\\python.exe -m pip install -U coloredlogs EmPy"
+  - "%PYTHON%\\python.exe -m pip install -U coloredlogs EmPy distlib"
   # tests_require, except pyenchant, additionally mock
   - "%PYTHON%\\python.exe -m pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes mock pep8-naming pylint pytest pytest-cov"
   # for uploading the coverage information to codecov

--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -152,16 +152,14 @@ def _next_incompatible_version(version):
     normalized = NormalizedVersion(version)
     parse_tuple = normalized.parse(version)
     version_tuple = parse_tuple[1]
-    limit = len(version_tuple) - 1
-    lt_string = ''
-    for i in range(limit):
-        if i != 0:
-            lt_string += '.'
-        v = version_tuple[i]
-        if i == limit - 1:
+    lt_string_parts = []
+    # the last part of the version tuple is dropped
+    for i, v in enumerate(version_tuple[:-1]):
+        # the second last part of the version tuple if being incremented
+        if i == len(version_tuple) - 2:
             v += 1
-        lt_string += str(v)
-    if len(lt_string) == 1:
-        # Version has minimum valid length
-        lt_string += '.0'
-    return lt_string
+        lt_string_parts.append(str(v))
+    if len(lt_string_parts) == 1:
+        # the version must have a minimum length
+        lt_string_parts.append('0')
+    return '.'.join(lt_string_parts)

--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -108,27 +108,27 @@ def create_dependency_descriptor(requirement_string):
 
     See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
-    :param requirement_string: a PEP440 compliant requirement string
-    :return: A descriptor with metadata from the requirement string
+    :param str requirement_string: a PEP440 compliant requirement string
+    :return: A descriptor with version constraints from the requirement string
     :rtype: DependencyDescriptor
     """
     symbol_mapping = {
+        '~=': 'version_compatible',
         '==': 'version_eq',
         '!=': 'version_neq',
-        '>': 'version_gt',
-        '<': 'version_lt',
         '<=': 'version_lte',
         '>=': 'version_gte',
-        '~=': 'version_compatible'
+        '>': 'version_gt',
+        '<': 'version_lt',
     }
 
     requirement = parse_requirement(requirement_string)
     metadata = {}
-    if requirement.constraints is not None:
-        for symbol, version in requirement.constraints:
-            if symbol in symbol_mapping:
-                metadata[symbol_mapping[symbol]] = version
-            else:
-                logger.warn('Could not parse {symbol} in {requirement}'
-                            .format(locals()))
+    for symbol, version in (requirement.constraints or []):
+        if symbol in symbol_mapping:
+            metadata[symbol_mapping[symbol]] = version
+        else:
+            logger.warn(
+                "Ignoring unknown symbol '{symbol}' in '{requirement}'"
+                .format(locals()))
     return DependencyDescriptor(requirement.name, metadata=metadata)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ keywords = colcon
 python_requires = >=3.5
 install_requires =
   coloredlogs; sys_platform == 'win32'
-  EmPy
   distlib
+  EmPy
   # the pytest dependency and its extensions are provided for convenience
   # even though they are only conditional
   pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ python_requires = >=3.5
 install_requires =
   coloredlogs; sys_platform == 'win32'
   EmPy
+  distlib
   # the pytest dependency and its extensions are provided for convenience
   # even though they are only conditional
   pytest

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [colcon-core]
-Depends3: python3-empy, python3-pytest, python3-pytest-cov, python3-pytest-runner, python3-setuptools
+Depends3: python3-distlib, python3-empy, python3-pytest, python3-pytest-cov, python3-pytest-runner, python3-setuptools
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -77,35 +77,35 @@ def test_identify():
 
 
 def test_create_dependency_descriptor():
-    eq_str = 'flake8==2.2.0'
+    eq_str = 'pkgname==2.2.0'
     dep = create_dependency_descriptor(eq_str)
     assert dep.metadata['version_eq'] == '2.2.0'
 
-    lt_str = 'flake8<2.3.0'
+    lt_str = 'pkgname<2.3.0'
     dep = create_dependency_descriptor(lt_str)
     assert dep.metadata['version_lt'] == '2.3.0'
 
-    lte_str = 'flake8<=2.2.0'
+    lte_str = 'pkgname<=2.2.0'
     dep = create_dependency_descriptor(lte_str)
     assert dep.metadata['version_lte'] == '2.2.0'
 
-    gt_str = 'flake8>2.3.0'
+    gt_str = 'pkgname>2.3.0'
     dep = create_dependency_descriptor(gt_str)
     assert dep.metadata['version_gt'] == '2.3.0'
 
-    gte_str = 'flake8>=2.2.0'
+    gte_str = 'pkgname>=2.2.0'
     dep = create_dependency_descriptor(gte_str)
     assert dep.metadata['version_gte'] == '2.2.0'
 
-    neq_str = 'flake8!=1.2.1'
+    neq_str = 'pkgname!=1.2.1'
     dep = create_dependency_descriptor(neq_str)
     assert dep.metadata['version_neq'] == '1.2.1'
 
-    neq_str = 'flake8~=1.4.1'
+    neq_str = 'pkgname~=1.4.1'
     dep = create_dependency_descriptor(neq_str)
     assert dep.metadata['version_compatible'] == '1.4.1'
 
-    multi_str = 'flake8<=3.2.0, >=2.2.0'
+    multi_str = 'pkgname<=3.2.0, >=2.2.0'
     dep = create_dependency_descriptor(multi_str)
     assert dep.metadata['version_gte'] == '2.2.0'
     assert dep.metadata['version_lte'] == '3.2.0'

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -6,7 +6,9 @@ from tempfile import TemporaryDirectory
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_identification.python \
-    import create_dependency_descriptor, PythonPackageIdentification
+    import create_dependency_descriptor
+from colcon_core.package_identification.python \
+    PythonPackageIdentification
 import pytest
 
 

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -101,9 +101,25 @@ def test_create_dependency_descriptor():
     dep = create_dependency_descriptor(neq_str)
     assert dep.metadata['version_neq'] == '1.2.1'
 
-    neq_str = 'pkgname~=1.4.1'
-    dep = create_dependency_descriptor(neq_str)
-    assert dep.metadata['version_compatible'] == '1.4.1'
+    compat_str = 'pkgname~=1.4.1a4'
+    dep = create_dependency_descriptor(compat_str)
+    assert dep.metadata['version_gte'] == '1.4.1a4'
+    assert dep.metadata['version_lt'] == '1.5'
+
+    compat_str = 'pkgname~=1.4.1'
+    dep = create_dependency_descriptor(compat_str)
+    assert dep.metadata['version_gte'] == '1.4.1'
+    assert dep.metadata['version_lt'] == '1.5'
+
+    compat_str = 'pkgname~=1.4.1.4'
+    dep = create_dependency_descriptor(compat_str)
+    assert dep.metadata['version_gte'] == '1.4.1.4'
+    assert dep.metadata['version_lt'] == '1.4.2'
+
+    compat_str = 'pkgname~=1.4'
+    dep = create_dependency_descriptor(compat_str)
+    assert dep.metadata['version_gte'] == '1.4'
+    assert dep.metadata['version_lt'] == '2.0'
 
     multi_str = 'pkgname<=3.2.0, >=2.2.0'
     dep = create_dependency_descriptor(multi_str)

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -116,10 +116,10 @@ def test_create_dependency_descriptor():
     assert dep.metadata['version_gte'] == '1.4.1.4'
     assert dep.metadata['version_lt'] == '1.4.2'
 
-    compat_str = 'pkgname~=1.4'
+    compat_str = 'pkgname~=11.12'
     dep = create_dependency_descriptor(compat_str)
-    assert dep.metadata['version_gte'] == '1.4'
-    assert dep.metadata['version_lt'] == '2.0'
+    assert dep.metadata['version_gte'] == '11.12'
+    assert dep.metadata['version_lt'] == '12.0'
 
     multi_str = 'pkgname<=3.2.0, >=2.2.0'
     dep = create_dependency_descriptor(multi_str)

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -8,7 +8,7 @@ from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_identification.python \
     import create_dependency_descriptor
 from colcon_core.package_identification.python \
-    PythonPackageIdentification
+    import PythonPackageIdentification
 import pytest
 
 


### PR DESCRIPTION
This adds version metadata to the dependencies created by python package identification. 

>Distlib is a library which implements low-level functions that relate to packaging and distribution of Python software. It consists in part of the functions in the packaging Python package, which was intended to be released as part of Python 3.3, but was removed shortly before Python 3.3 entered beta testing.

It seems like distlib is the correct library to use for the parsing functionality. Pip uses distlib as seen [here](https://github.com/pypa/pip/blob/873662179aebbf5eacdf681078f47bbfe5ee6149/src/pip/_vendor/distlib.pyi#L1).