### PR TITLE
add desc order in changelog link

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = colcon-core
 version = attr: colcon_core.__version__
 url = https://colcon.readthedocs.io
 project_urls =
-    Changelog = https://github.com/colcon/colcon-core/milestones?state=closed
+    Changelog = https://github.com/colcon/colcon-core/milestones?direction=desc&sort=due_date&state=closed
     GitHub = https://github.com/colcon/colcon-core/
 author = Dirk Thomas
 author_email = web@dirk-thomas.net


### PR DESCRIPTION
To avoid relying on the lastest updated timestamp.