### PR TITLE
Bug when setting a python executable and it is not used

### DIFF
--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -75,7 +75,7 @@ goto:eof
     :: use the Python executable known at configure time
     set "_colcon_python_executable=@(python_executable)"
     :: if it doesn't exist try a fall back
-    if not exist "%_colcon_python_executable%" (
+    if not exist "!_colcon_python_executable!" (
       python --version > NUL 2> NUL
       if errorlevel 1 (
         echo error: unable to find python executable


### PR DESCRIPTION
Came across this problem when trying to use a python executable but it was not detected. it was comparing an empty string.

A set is done inside the if statement and evaluated inside the if statement, therefore the variable should use delayed expansion as variable expansion occurs when the if statement is evaluated. 

More info about the topic can be found [here](https://blogs.msdn.microsoft.com/oldnewthing/20060823-00/?p=29993).