### PR TITLE
update code and flake8 arguments to pass with flake8 3.6.x / pycodestyle 2.4.x

### DIFF
--- a/colcon_core/argument_parser/__init__.py
+++ b/colcon_core/argument_parser/__init__.py
@@ -70,7 +70,7 @@ def decorate_argument_parser(parser):
                 parser=parser)
             assert hasattr(decorated_parser, 'add_argument'), \
                 'decorate_argument_parser() should return a parser like object'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in decorator extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -246,7 +246,7 @@ class LogLevelAction(argparse.Action):
         """See :class:`argparse.Action.__call__`."""
         try:
             value = get_numeric_log_level(values)
-        except ValueError as e:
+        except ValueError as e:  # noqa: F841
             parser.error(
                 '{option_string} has unsupported value, {e}'
                 .format_map(locals()))
@@ -443,13 +443,13 @@ def verb_main(context, logger):
         rc = context.args.main(context=context)
     except KeyboardInterrupt:
         rc = signal.SIGINT
-    except RuntimeError as e:
+    except RuntimeError as e:  # noqa: F841
         # only log the error message for "known" exceptions
         logger.error(
             '{context.command_name} {context.args.verb_name}: {e}'
             .format_map(locals()))
         return 1
-    except Exception as e:
+    except Exception as e:  # noqa: F841
         # log the error message and a traceback for "unexpected" exceptions
         exc = traceback.format_exc()
         logger.error(

--- a/colcon_core/entry_point.py
+++ b/colcon_core/entry_point.py
@@ -98,7 +98,7 @@ def load_entry_points(group_name):
             extension_type = load_entry_point(entry_point)
         except RuntimeError:
             continue
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised when loading entry point
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -115,7 +115,7 @@ def create_environment_scripts(
                     prefix_path, pkg.name, hook_tuples)
                 assert retval is None, \
                     'create_package_script() should return None'
-            except Exception as e:
+            except Exception as e:  # noqa: F841
                 # catch exceptions raised in shell extension
                 exc = traceback.format_exc()
                 logger.error(
@@ -147,7 +147,7 @@ def create_environment_hooks(prefix_path, pkg_name):
             hooks = extension.create_environment_hooks(prefix_path, pkg_name)
             assert isinstance(hooks, Iterable), \
                 'create_environment_hooks() should return an iterable'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in environment extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/event_reactor.py
+++ b/colcon_core/event_reactor.py
@@ -77,7 +77,7 @@ class EventReactor(Thread):
             try:
                 retval = observer(event)
                 assert retval is None, 'event handler should return None'
-            except Exception as e:
+            except Exception as e:  # noqa: F841
                 # catch exceptions raised in event handler extension
                 exc = traceback.format_exc()
                 logger.error(

--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -221,7 +221,7 @@ def add_executor_arguments(parser):
             try:
                 retval = extension.add_arguments(parser=group)
                 assert retval is None, 'add_arguments() should return None'
-            except Exception as e:
+            except Exception as e:  # noqa: F841
                 # catch exceptions raised in executor extension
                 exc = traceback.format_exc()
                 logger.error(
@@ -266,7 +266,7 @@ def execute_jobs(context, jobs, *, abort_on_error=True):
     try:
         rc = executor.execute(
             context.args, jobs, abort_on_error=abort_on_error)
-    except Exception as e:
+    except Exception as e:  # noqa: F841
         # catch exceptions raised in executor extension
         exc = traceback.format_exc()
         logger.error(

--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -65,7 +65,7 @@ class SequentialExecutor(ExecutorExtensionPoint):
                         "run_until_complete '{name}' finished"
                         .format_map(locals()))
                     return signal.SIGINT
-                except Exception as e:
+                except Exception as e:  # noqa: F841
                     exc = traceback.format_exc()
                     logger.error(
                         "Exception in job execution '{name}': {e}\n{exc}"

--- a/colcon_core/logging.py
+++ b/colcon_core/logging.py
@@ -31,7 +31,7 @@ def set_logger_level_from_env(logger, env_name):
     if log_level:
         try:
             numeric_log_level = get_numeric_log_level(log_level)
-        except ValueError as e:
+        except ValueError as e:  # noqa: F841
             logger.warning(
                 "environment variable '{env_name}' has unsupported value "
                 "'{log_level}', {e}".format_map(locals()))

--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -98,7 +98,7 @@ def augment_packages(
                 descs,
                 additional_argument_names=additional_argument_names)
             assert retval is None, 'augment_packages() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in augmentation extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -114,7 +114,7 @@ def add_package_discovery_arguments(parser, *, extensions=None):
     for name, extension in extensions.items():
         try:
             has_default = extension.has_default()
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in discovery extension
             exc = traceback.format_exc()
             logger.error(
@@ -134,7 +134,7 @@ def add_package_discovery_arguments(parser, *, extensions=None):
             retval = extension.add_arguments(
                 parser=group, with_default=with_default)
             assert retval is None, 'add_arguments() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in discovery extension
             exc = traceback.format_exc()
             logger.error(
@@ -197,7 +197,7 @@ def _get_extensions_with_parameters(
             'parameters'.format_map(locals()))
         try:
             has_parameter = extension.has_parameters(args=args)
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in discovery extension
             exc = traceback.format_exc()
             logger.error(
@@ -227,7 +227,7 @@ def _discover_packages(
         except NotImplementedError:
             # skip extension not implementing discovery
             continue
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in discovery extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/package_identification/__init__.py
+++ b/colcon_core/package_identification/__init__.py
@@ -137,7 +137,7 @@ def _identify(extensions_same_prio, desc):
         except IgnoreLocationException:
             logger.log(1, '_identify(%s) ignored', desc.path)
             raise
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in identification extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -108,7 +108,7 @@ def _add_package_selection_arguments(parser):
         try:
             retval = extension.add_arguments(parser=group)
             assert retval is None, 'add_arguments() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in package selection extension
             exc = traceback.format_exc()
             logger.error(
@@ -197,7 +197,7 @@ def _check_package_selection_parameters(args, pkg_names):
         try:
             retval = extension.check_parameters(args=args, pkg_names=pkg_names)
             assert retval is None, 'check_parameters() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in package selection extension
             exc = traceback.format_exc()
             logger.error(
@@ -224,7 +224,7 @@ def select_package_decorators(args, decorators):
             retval = extension.select_packages(
                 args=args, decorators=decorators)
             assert retval is None, 'select_packages() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in package selection extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/plugin_system.py
+++ b/colcon_core/plugin_system.py
@@ -61,12 +61,12 @@ def _instantiate_extension(
         extension_instance = extension_class()
         assert isinstance(extension_instance, object), \
             'invocation should return an object'
-    except SkipExtensionException as e:
+    except SkipExtensionException as e:  # noqa: F841
         logger.info(
             "Skipping extension '{group_name}.{extension_name}': {e}"
             .format_map(locals()))
         extension_instance = None
-    except Exception as e:
+    except Exception as e:  # noqa: F841
         # catch exceptions raised in extension constructor
         exc = traceback.format_exc()
         logger.error(

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -235,7 +235,7 @@ async def get_command_environment(task_name, build_base, dependencies):
                 logger.debug(
                     "Skip shell extension '{extension.SHELL_NAME}' for "
                     'command environment'.format_map(locals()))
-            except SkipExtensionException as e:
+            except SkipExtensionException as e:  # noqa: F841
                 # skip extension, continue with next one
                 logger.info(
                     "Skip shell extension '{extension.SHELL_NAME}' for "
@@ -244,7 +244,7 @@ async def get_command_environment(task_name, build_base, dependencies):
                 # re-raise same exception to handle it in the executor
                 # without a traceback
                 raise
-            except Exception as e:
+            except Exception as e:  # noqa: F841
                 # catch exceptions raised in shell extension
                 exc = traceback.format_exc()
                 logger.error(
@@ -325,7 +325,7 @@ def create_environment_hook(
                         'create_hook_prepend_value() should return a Path ' \
                         'object'
 
-                except Exception as e:
+                except Exception as e:  # noqa: F841
                     # catch exceptions raised in shell extension
                     exc = traceback.format_exc()
                     logger.error(

--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -31,7 +31,7 @@ def expand_template(template_path, destination_path, data):
             content = h.read()
         interpreter.string(content, str(template_path), locals=data)
         output = output.getvalue()
-    except Exception as e:
+    except Exception as e:  # noqa: F841
         logger.error(
             "{e.__class__.__name__} processing template '{template_path}'"
             .format_map(locals()))

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -49,10 +49,10 @@ async def run(
     stdout_callback: Callable[[bytes], None],
     stderr_callback: Callable[[bytes], None],
     *,
-    cwd: str=None,
-    env: Mapping[str, str]=None,
-    shell: bool=False,
-    use_pty: UsePtyType=None
+    cwd: str = None,
+    env: Mapping[str, str] = None,
+    shell: bool = False,
+    use_pty: UsePtyType = None
 ) -> subprocess.CompletedProcess:
     """
     Run the command described by args.
@@ -89,9 +89,9 @@ async def run(
 async def check_output(
     args: Sequence[str],
     *,
-    cwd: str=None,
-    env: Mapping[str, str]=None,
-    shell: bool=False
+    cwd: str = None,
+    env: Mapping[str, str] = None,
+    shell: bool = False
 ) -> subprocess.CompletedProcess:
     """
     Get the output of an invoked command.

--- a/colcon_core/task/__init__.py
+++ b/colcon_core/task/__init__.py
@@ -192,7 +192,7 @@ def add_task_arguments(parser, task_name):
         try:
             retval = extension.add_arguments(parser=group)
             assert retval is None, 'add_arguments() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in task extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -52,7 +52,7 @@ class PythonTestTask(TaskExtensionPoint):
                     1, "test() by extension '{key}'".format_map(locals()))
                 try:
                     matched = extension.match(self.context, env, setup_py_data)
-                except Exception as e:
+                except Exception as e:  # noqa: F841
                     # catch exceptions raised in python testing step extension
                     exc = traceback.format_exc()
                     logger.error(
@@ -73,7 +73,7 @@ class PythonTestTask(TaskExtensionPoint):
             1, "test.step() by extension '{key}'".format_map(locals()))
         try:
             return await extension.step(self.context, env, setup_py_data)
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in python testing step extension
             exc = traceback.format_exc()
             logger.error(
@@ -176,7 +176,7 @@ def add_python_testing_step_arguments(parser):
         try:
             retval = extension.add_arguments(parser=parser)
             assert retval is None, 'add_arguments() should return None'
-        except Exception as e:
+        except Exception as e:  # noqa: F841
             # catch exceptions raised in package selection extension
             exc = traceback.format_exc()
             logger.error(

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -252,7 +252,7 @@ class BuildVerb(VerbExtensionPoint):
                         Path(install_base), merge_install)
                     assert retval is None, \
                         'create_prefix_script() should return None'
-                except Exception as e:
+                except Exception as e:  # noqa: F841
                     # catch exceptions raised in shell extension
                     exc = traceback.format_exc()
                     logger.error(

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -15,11 +15,12 @@ LOG.setLevel(logging.WARN)
 
 def test_flake8():
     style_guide = get_style_guide(
-        ignore=['D100', 'D104'],
+        ignore=['D100', 'D104', 'W504'],
         show_source=True,
     )
     style_guide_tests = get_style_guide(
-        ignore=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107'],
+        ignore=[
+            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107', 'W504'],
         show_source=True,
     )
 


### PR DESCRIPTION
* Comply with rule `E252` - missing whitespace around annotated parameter equals.
* Ignoring the new warning `W504` - which is ignored by default.

The following change should be reverted once Python 3.5 support is dropped and f-strings can be used:

* Ignore rule `F841` on lines which contain variables which are only used in string which are being formatted with `.format_map(locals())`.

