### PR TITLE
replace 'typeset' usage in sh with 'command'

### DIFF
--- a/colcon_core/shell/template/package.sh.em
+++ b/colcon_core/shell/template/package.sh.em
@@ -20,7 +20,7 @@ colcon_prepend_unique_value() {
   # start with the new value
   _all_values="$_value"
   # workaround SH_WORD_SPLIT not being set in zsh
-  if typeset -f colcon_zsh_convert_to_array > /dev/null; then
+  if [ "$(command -v colcon_zsh_convert_to_array)" ]; then
     colcon_zsh_convert_to_array _values
   fi
   # iterate over existing values in the variable


### PR DESCRIPTION
Addresses the problem reported in https://github.com/ros-infrastructure/ros_buildfarm/pull/585#discussion_r228625674 that a `.sh` snippet uses `typeset` which is bash specific.