### PR TITLE
fix flake8 test logic

### DIFF
--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -45,10 +45,14 @@ def test_flake8():
     if total_errors:  # pragma: no cover
         # output summary with per-category counts
         print()
-        report._application.formatter.show_statistics(report._stats)
+        if report.total_errors:
+            report._application.formatter.show_statistics(report._stats)
+        if report_tests.total_errors:
+            report_tests._application.formatter.show_statistics(
+                report_tests._stats)
         print(
             'flake8 reported {total_errors} errors'
             .format_map(locals()), file=sys.stderr)
 
-    assert not report.total_errors, \
+    assert not total_errors, \
         'flake8 reported {total_errors} errors'.format_map(locals())

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -20,12 +20,12 @@ def test_flake8():
     log.setLevel(logging.WARN)
 
     style_guide = get_style_guide(
-        ignore=['D100', 'D104', 'W504'],
+        extend_ignore=['D100', 'D104'],
         show_source=True,
     )
     style_guide_tests = get_style_guide(
-        ignore=[
-            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107', 'W504'],
+        extend_ignore=[
+            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107'],
         show_source=True,
     )
 


### PR DESCRIPTION
Failures in the `test` directory where not reported correctly.

The second commit uses the new option `--extend-ignore` in `flake8` to avoid having to enumerate codes which are ignored by default.