### PR TITLE
handle multiline environment variables

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -282,7 +282,7 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
                 "encoding '{encoding}': {line_replaced}".format_map(locals()))
             continue
         parts = line.split('=', 1)
-        if len(parts) == 2 and re.match('^[a-zA-Z_][a-zA-Z0-9_%]*$', parts[0]):
+        if len(parts) == 2 and re.match('^[a-zA-Z0-9_%]+$', parts[0]):
             # add new environment variable
             env[parts[0]] = parts[1]
         else:

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -288,8 +288,8 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
         else:
             # assume a line without an equal sign or with a "key" which is not
             # a valid name is a continuation of the previous line
-            assert env
-            env[list(env.keys())[-1]] += '\n' + line
+            if env:
+                env[list(env.keys())[-1]] += '\n' + line
     assert len(env) > 0, "The environment shouldn't be empty"
     return env
 

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -6,6 +6,7 @@ from concurrent.futures import CancelledError
 import locale
 import os
 from pathlib import Path
+import re
 import traceback
 
 from colcon_core.environment_variable import EnvironmentVariable
@@ -266,24 +267,29 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
     :rtype: dict
     """
     output = await check_output(cmd, cwd=cwd, shell=shell)
-    env = {}
+    env = OrderedDict()
     for line in output.splitlines():
         line = line.rstrip()
         if not line:
             continue
         encoding = locale.getpreferredencoding()
         try:
-            parts = line.decode(encoding).split('=', 1)
+            line = line.decode(encoding)
         except UnicodeDecodeError:
             line_replaced = line.decode(encoding=encoding, errors='replace')
             logger.warning(
                 'Failed to decode line from the environment using the '
                 "encoding '{encoding}': {line_replaced}".format_map(locals()))
             continue
-        if len(parts) != 2:
-            # skip lines which don't contain an equal sign
-            continue
-        env[parts[0]] = parts[1]
+        parts = line.split('=', 1)
+        if len(parts) == 2 and re.match('^[a-zA-Z_][a-zA-Z0-9_%]*$', parts[0]):
+            # add new environment variable
+            env[parts[0]] = parts[1]
+        else:
+            # assume a line without an equal sign or with a "key" which is not
+            # a valid name is a continuation of the previous line
+            assert env
+            env[list(env.keys())[-1]] += '\n' + line
     assert len(env) > 0, "The environment shouldn't be empty"
     return env
 

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -120,7 +120,7 @@ def test_get_command_environment():
 
 def test_get_environment_variables():
     cmd = [
-        'echo', 'NAME=value\n\nSOMETHING\nNAME2=value with spaces']
+        'echo', 'FOO\nNAME=value\n\nSOMETHING\nNAME2=value with spaces']
 
     coroutine = get_environment_variables(cmd, shell=False)
     env = run_until_complete(coroutine)

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -127,7 +127,7 @@ def test_get_environment_variables():
 
     assert len(env.keys()) == 2
     assert 'NAME' in env.keys()
-    assert env['NAME'] == 'value'
+    assert env['NAME'] == 'value\nSOMETHING'
     assert 'NAME2' in env.keys()
     assert env['NAME2'] == 'value with spaces'
 


### PR DESCRIPTION
Handle some cases where environment variable are consisting of multiple lines, e.g.:

```
BASH_FUNC_module%%=() {  _moduleraw "$@" 2>&1
}
```

The patch won't do the right thing for multiline variables where the following lines still look like "key=value":

```
FOO="bar
BAZ=qux"
```

An alternative would be to use a different separator (e.g. using `env -0`) but that option is not available on macOS.