### PR TITLE
create unique log directory, avoiding race

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -19,6 +19,7 @@ lstrip
 mkdtemp
 nargs
 nonlocal
+noop
 noqa
 pathlib
 pkgname
@@ -44,5 +45,6 @@ thomas
 todo
 traceback
 tuples
+unlinking
 veyor
 wildcards


### PR DESCRIPTION
~~Maybe addressing~~ Fixes #129.

The patch ensures that the log directory doesn't exist yet. If it does a serial number is appended until it doesn't.

Without the patch two invocations started in the same second were writing to the same log directory.