### PR TITLE
Enabling symlink creation on Windows

### DIFF
--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -3,7 +3,6 @@
 
 import os
 from pathlib import Path
-import sys
 import uuid
 
 from colcon_core.logging import colcon_logger
@@ -121,10 +120,12 @@ def create_log_path(verb_name):
     A `COLCON_IGNORE` marker file is being placed in the parent directory of
     the logging directory to avoid it being crawled for packages.
 
-    On non-Windows platforms two symlinks are created as siblings of the log
-    path:
+    Two symlinks are created as siblings of the log path:
     * `latest_<verb_name>` linking to the log path
     * `latest` linking to `latest_<verb_name>`
+
+    On Windows platforms, Administrator privilges are required to create
+    these symlinks.
 
     :param str verb_name: The verb name
     """
@@ -164,8 +165,6 @@ def create_log_path(verb_name):
     ignore_marker.touch()
 
     # create latest symlinks
-    if sys.platform == 'win32':
-        return
     _create_symlink(
         path, path.parent / 'latest_{verb_name}'.format_map(locals()))
     _create_symlink(
@@ -198,6 +197,9 @@ def _create_symlink(src, dst):
     try:
         os.symlink(str(src), str(dst))
     except FileNotFoundError:
+        pass
+    except OSError:
+        # Administrator privileges are required on Windows
         pass
 
 

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -124,7 +124,7 @@ def create_log_path(verb_name):
     * `latest_<verb_name>` linking to the log path
     * `latest` linking to `latest_<verb_name>`
 
-    On Windows platforms, Administrator privilges are required to create
+    On Windows platforms, Administrator privileges are required to create
     these symlinks.
 
     :param str verb_name: The verb name

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -124,8 +124,9 @@ def create_log_path(verb_name):
     * `latest_<verb_name>` linking to the log path
     * `latest` linking to `latest_<verb_name>`
 
-    On Windows platforms, Administrator privileges are required to create
+    On Windows platforms Administrator privileges are required to create
     these symlinks.
+    Otherwise they are being skipped.
 
     :param str verb_name: The verb name
     """

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -3,7 +3,6 @@
 
 import os
 from pathlib import Path
-import sys
 from tempfile import TemporaryDirectory
 
 from colcon_core import location
@@ -143,10 +142,6 @@ def test_create_log_path():
                 log_path / subdirectory) + '_3'
         assert (log_path / (str(subdirectory) + '_3')).exists()
         subdirectory += '_3'
-
-        # skip all symlink tests on Windows for now
-        if sys.platform == 'win32':
-            return
 
         # check that `latest_verb` was created and points to the subdirectory
         assert (log_path / 'latest_verb').is_symlink()

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -209,3 +209,14 @@ def test__create_symlink():
         with patch('os.symlink') as symlink:
             _create_symlink(path / 'src', DummyPath())
             assert symlink.call_count == 1
+
+        # (Windows) OSError: symbolic link privilege not held
+        class ValidPath(DummyPath):
+
+            def is_symlink(self):
+                return False
+
+        with patch('os.symlink') as symlink:
+            symlink.side_effect = OSError()
+            _create_symlink(path / 'src', ValidPath())
+            assert symlink.call_count == 1


### PR DESCRIPTION
This adds symlink creation for Windows for 'latest {Verb}'. Currently os.symlink only works when run with administrator privileges and it will throw an OSError if symlink privileges are not available.