### PR TITLE
underscore prefix shell function which can't be unset

### DIFF
--- a/colcon_core/shell/template/hook_prepend_value.sh.em
+++ b/colcon_core/shell/template/hook_prepend_value.sh.em
@@ -5,4 +5,4 @@ value = '$COLCON_CURRENT_PREFIX'
 if subdirectory:
     value += '/' + subdirectory
 }@
-colcon_prepend_unique_value @(name) "@(value)"
+_colcon_prepend_unique_value @(name) "@(value)"

--- a/colcon_core/shell/template/package.sh.em
+++ b/colcon_core/shell/template/package.sh.em
@@ -7,7 +7,7 @@
 # duplicates as well as trailing separators are avoided
 # first argument: the name of the result variable
 # second argument: the value to be prepended
-colcon_prepend_unique_value() {
+_colcon_prepend_unique_value() {
   # arguments
   _listname="$1"
   _value="$2"
@@ -90,4 +90,4 @@ unset _colcon_package_sh_source_script
 unset COLCON_CURRENT_PREFIX
 @[end if]@
 
-# do not unset colcon_prepend_unique_value since it might be used by non-primary shell hooks
+# do not unset _colcon_prepend_unique_value since it might be used by non-primary shell hooks


### PR DESCRIPTION
Since the function can't be unset (as described in the touched comment) it should be prefixed with an underscore so that it doesn't appear in the completion when typing `colco<tab>`.