### PR TITLE
collections.abc

### DIFF
--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from collections import Iterable
+from collections.abc import Iterable
 import os
 from pathlib import Path
 import traceback


### PR DESCRIPTION
This updates an import statement with regards to the collections deprecated namespace.

This addresses issue #136 