### PR TITLE
add OnError enum to configure the executor behavior when a job fails

### DIFF
--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -8,6 +8,7 @@ import sys
 import traceback
 
 from colcon_core.executor import ExecutorExtensionPoint
+from colcon_core.executor import OnError
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.subprocess import new_event_loop
@@ -28,7 +29,9 @@ class SequentialExecutor(ExecutorExtensionPoint):
         satisfies_version(
             ExecutorExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
-    def execute(self, args, jobs, *, abort_on_error=True):  # noqa: D102
+    def execute(self, args, jobs, *, on_error=OnError.interrupt):  # noqa: D102
+        abort_on_error = on_error == OnError.interrupt
+
         # avoid debug message from asyncio when colcon uses debug log level
         asyncio_logger = logging.getLogger('asyncio')
         asyncio_logger.setLevel(logging.INFO)

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -15,6 +15,7 @@ from colcon_core.executor import execute_jobs
 from colcon_core.executor import ExecutorExtensionPoint
 from colcon_core.executor import get_executor_extensions
 from colcon_core.executor import Job
+from colcon_core.executor import OnError
 from colcon_core.subprocess import SIGINT_RESULT
 from mock import Mock
 from mock import patch
@@ -224,8 +225,9 @@ def test_execute_jobs():
             event_reactor.get_queue().put.reset_mock()
             jobs['one'].returncode = 0
             extensions = get_executor_extensions()
-            extensions[110]['extension2'].execute = Mock(return_value=0)
-            rc = execute_jobs(context, jobs)
+            extensions[110]['extension2'].execute = \
+                lambda args, jobs, on_error: 0
+            rc = execute_jobs(context, jobs, on_error=OnError.interrupt)
             assert rc is 0
             assert event_reactor.get_queue().put.call_count == 1
             assert isinstance(

--- a/test/test_executor_sequential.py
+++ b/test/test_executor_sequential.py
@@ -9,6 +9,7 @@ import sys
 from threading import Thread
 import time
 
+from colcon_core.executor import OnError
 from colcon_core.executor.sequential import SequentialExecutor
 import pytest
 
@@ -61,7 +62,7 @@ def test_sequential():
 
     # continue after error, keeping first error code
     jobs['five'] = job5
-    rc = extension.execute(args, jobs, abort_on_error=False)
+    rc = extension.execute(args, jobs, on_error=OnError.continue_)
     assert rc == 2
     assert ran_jobs == ['job1', 'job4']
     ran_jobs.clear()


### PR DESCRIPTION
Adds an `OnError` enum to offer more fine grain control about the executor behavior in case a job fails. The new keyword argument is introduced in a backward compatible way so that existing code calling the global function `colcon_core.executor.execute_jobs` as well as existing `ExecutorExtensionPoint.execute` methods continue to work.

The patch does neither modify the verbs to make use of the additional on-error values nor the executors to make use of the new keyword argument.