### PR TITLE
Refactorings / cleanup

### DIFF
--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -63,7 +63,7 @@ class PackageSelectionExtensionPoint:
         This method must be overridden in a subclass.
 
         :param args: The parsed command line arguments
-        :param list decorators: The package decorators
+        :param list decorators: The package decorators in topological order
         """
         raise NotImplementedError()
 
@@ -214,7 +214,7 @@ def select_package_decorators(args, decorators):
     The `selected` attribute of each decorator is updated by this function.
 
     :param args: The parsed command line arguments
-    :param list decorators: The package decorators
+    :param list decorators: The package decorators in topological order
     """
     # filtering must happen after the topological ordering since otherwise
     # packages in the middle of the dependency graph might be missing

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 from collections import OrderedDict
-import copy
-import logging
 import os
 from pathlib import Path
 import traceback
@@ -27,6 +25,7 @@ from colcon_core.task import TaskContext
 from colcon_core.verb import check_and_mark_build_tool
 from colcon_core.verb import check_and_mark_install_layout
 from colcon_core.verb import logger
+from colcon_core.verb import update_object
 from colcon_core.verb import VerbExtensionPoint
 
 
@@ -58,75 +57,18 @@ class BuildPackageArguments:
             os.getcwd(), args.test_result_base, pkg.name)) \
             if args.test_result_base else None
 
-        # set additional arguments from the command line or package metadata
+        # set additional arguments
         for dest in (additional_destinations or []):
+            # from the command line
             if hasattr(args, dest):
                 update_object(
                     self, dest, getattr(args, dest),
-                    pkg.name, 'command line')
+                    pkg.name, 'build', 'command line')
+            # from the package metadata
             if dest in pkg.metadata:
                 update_object(
                     self, dest, pkg.metadata[dest],
-                    pkg.name, 'package metadata')
-
-
-def update_object(object_, key, value, package_name, value_source):
-    """
-    Set or update an attribute of an object.
-
-    If the attribute exists and the passed value as well as the current value
-    of the attribute are dictionaries then the current values are being updated
-    with the passed values.
-
-    If the attribute exists and the passed value as well as the current value
-    of the attribute are lists then the passed values are being appended to the
-    current values.
-
-    Otherwise the attribute is being set to the passed value potentially
-    overwriting an existing value.
-
-    :param key: The name of the attributes
-    :param value: The value used to set or update the attribute
-    :param str package_name: The package name, only used for log messages
-    :param str value_source: The source of the value, only used for log
-      messages
-    """
-    if not hasattr(object_, key):
-        logger.log(
-            5, "set package '{package_name}' build argument '{key}' from "
-            "{value_source} to '{value}'".format_map(locals()))
-        # add value to the object
-        # copy value to avoid changes to either of them to affect each other
-        setattr(object_, key, copy.deepcopy(value))
-        return
-
-    old_value = getattr(object_, key)
-    if isinstance(old_value, dict) and isinstance(value, dict):
-        logger.log(
-            5, "update package '{package_name}' build argument '{key}' from "
-            "{value_source} with '{value}'".format_map(locals()))
-        # update dictionary
-        old_value.update(value)
-        return
-
-    if isinstance(old_value, list) and isinstance(value, list):
-        logger.log(
-            5, "extend package '{package_name}' build argument '{key}' from "
-            "{value_source} with '{value}'".format_map(locals()))
-        # extend list
-        old_value += value
-        return
-
-    severity = 5 \
-        if old_value is None or type(old_value) == type(value) \
-        else logging.WARNING
-    logger.log(
-        severity, "overwrite package '{package_name}' build argument '{key}' "
-        "from {value_source} with '{value}' (before: '{old_value}')"
-        .format_map(locals()))
-    # overwrite existing value
-    # copy value to avoid changes to either of them to affect each other
-    setattr(object_, key, copy.deepcopy(value))
+                    pkg.name, 'build', 'package metadata')
 
 
 class BuildVerb(VerbExtensionPoint):

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -24,8 +24,7 @@ def test_flake8():
         show_source=True,
     )
     style_guide_tests = get_style_guide(
-        extend_ignore=[
-            'D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107'],
+        extend_ignore=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107'],
         show_source=True,
     )
 


### PR DESCRIPTION
These changes came up while working on other stuff:

* Refactor `update_object` to be reused across verbs.
* Clarify the order of the data in the parameter.
* Nitpick line wrapping change.