### PR TITLE
fix symlink replacement logic

### DIFF
--- a/colcon_core/task/__init__.py
+++ b/colcon_core/task/__init__.py
@@ -259,11 +259,12 @@ def install(args, rel_src, rel_dst):
             os.unlink(dst)
         shutil.copy(src, dst)
     else:
-        if os.path.exists(dst):
-            if not os.path.islink(dst) or not os.path.samefile(src, dst):
-                if os.path.isfile(dst):
-                    os.remove(dst)
-                if os.path.isdir(dst):
-                    shutil.rmtree(dst)
+        if os.path.islink(dst):
+            if not os.path.exists(dst) or not os.path.samefile(src, dst):
+                os.unlink(dst)
+        elif os.path.isfile(dst):
+                os.remove(dst)
+        elif os.path.isdir(dst):
+                shutil.rmtree(dst)
         if not os.path.exists(dst):
             os.symlink(src, dst)

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -272,12 +272,13 @@ class PythonBuildTask(TaskExtensionPoint):
             src = os.path.join(args.path, item)
             dst = os.path.join(args.build_base, item)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
-            if os.path.exists(dst):
-                if not os.path.islink(dst) or not os.path.samefile(src, dst):
-                    if os.path.isfile(dst):
-                        os.remove(dst)
-                    elif os.path.isdir(dst):
-                        shutil.rmtree(dst)
+            if os.path.islink(dst):
+                if not os.path.exists(dst) or not os.path.samefile(src, dst):
+                    os.unlink(dst)
+            elif os.path.isfile(dst):
+                    os.remove(dst)
+            elif os.path.isdir(dst):
+                    shutil.rmtree(dst)
             if not os.path.exists(dst):
                 os.symlink(src, dst)
 

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -250,3 +250,11 @@ def test_install():
         assert path.is_symlink()
         assert path.samefile(os.path.join(args.path, 'source.txt'))
         assert path.read_text() == 'content'
+
+        # symlink exists, but to a not existing location
+        os.remove(os.path.join(args.path, 'source.txt'))
+        install(args, 'source2.txt', 'destination.txt')
+        path = Path(base_path) / 'install' / 'destination.txt'
+        assert path.is_file()
+        assert path.is_symlink()
+        assert path.samefile(os.path.join(args.path, 'source2.txt'))


### PR DESCRIPTION
Fix the logic for the case where the `dst` symlink exists but points to a not existing `src`.