### PR TITLE
fix spelling of test function

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -14,7 +14,6 @@ deps
 descs
 getpid
 iterdir
-licence
 lstrip
 mkdtemp
 nargs

--- a/test/test_copyright_license.py
+++ b/test/test_copyright_license.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 
 
-def test_copyright_licence():
+def test_copyright_license():
     missing = check_files([
         Path(__file__).parents[1],
         Path(__file__).parents[1] / 'bin' / 'colcon',


### PR DESCRIPTION
The same spelling mistake is present in all other packages. For those it will be fixed with the transition to `scspell`.