### PR TITLE
comply with stricter style checks

### DIFF
--- a/colcon_core/task/__init__.py
+++ b/colcon_core/task/__init__.py
@@ -263,8 +263,8 @@ def install(args, rel_src, rel_dst):
             if not os.path.exists(dst) or not os.path.samefile(src, dst):
                 os.unlink(dst)
         elif os.path.isfile(dst):
-                os.remove(dst)
+            os.remove(dst)
         elif os.path.isdir(dst):
-                shutil.rmtree(dst)
+            shutil.rmtree(dst)
         if not os.path.exists(dst):
             os.symlink(src, dst)

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -276,9 +276,9 @@ class PythonBuildTask(TaskExtensionPoint):
                 if not os.path.exists(dst) or not os.path.samefile(src, dst):
                     os.unlink(dst)
             elif os.path.isfile(dst):
-                    os.remove(dst)
+                os.remove(dst)
             elif os.path.isdir(dst):
-                    shutil.rmtree(dst)
+                shutil.rmtree(dst)
             if not os.path.exists(dst):
                 os.symlink(src, dst)
 

--- a/test/test_argument_parser.py
+++ b/test/test_argument_parser.py
@@ -129,5 +129,5 @@ def test_argument_parser_decorator():
     args = parser.parse_args(['ARG1', '--arg2', 'do', 'ARG3'])
     assert args.arg1 == 'ARG1'
     assert args.arg2 is True
-    assert args.verb is 'do'
-    assert args.arg3 is 'ARG3'
+    assert args.verb == 'do'
+    assert args.arg3 == 'ARG3'

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -63,14 +63,14 @@ def test_job():
 
     # successful task
     rc = run_until_complete(job())
-    assert rc is 0
+    assert rc == 0
     assert len(events) == 3
     assert isinstance(events[-2][0], JobStarted)
     assert events[-2][0].identifier == 'name'
     assert events[-2][1] == job
     assert isinstance(events[-1][0], JobEnded)
     assert events[-1][0].identifier == 'name'
-    assert events[-1][0].rc is 0
+    assert events[-1][0].rc == 0
     assert events[-1][1] == job
 
     # canceled task
@@ -101,21 +101,21 @@ def test_job():
     assert events[-2][1] == job
     assert isinstance(events[-1][0], JobEnded)
     assert events[-1][0].identifier == 'name'
-    assert events[-1][0].rc is 1
+    assert events[-1][0].rc == 1
     assert events[-1][1] == job
 
     # override task return code
     job.returncode = 2
     task.return_value = 0
     rc = run_until_complete(job())
-    assert rc is 2
+    assert rc == 2
     assert len(events) == 10
     assert isinstance(events[-2][0], JobStarted)
     assert events[-2][0].identifier == 'name'
     assert events[-2][1] == job
     assert isinstance(events[-1][0], JobEnded)
     assert events[-1][0].identifier == 'name'
-    assert events[-1][0].rc is 2
+    assert events[-1][0].rc == 2
     assert events[-1][1] == job
 
 
@@ -208,7 +208,7 @@ def test_execute_jobs():
             context.args.executor = 'extension2'
             with patch('colcon_core.executor.logger.error') as error:
                 rc = execute_jobs(context, jobs)
-            assert rc is 1
+            assert rc == 1
             assert error.call_count == 1
             assert len(error.call_args[0]) == 1
             assert error.call_args[0][0].startswith(
@@ -228,7 +228,7 @@ def test_execute_jobs():
             extensions[110]['extension2'].execute = \
                 lambda args, jobs, on_error: 0
             rc = execute_jobs(context, jobs, on_error=OnError.interrupt)
-            assert rc is 0
+            assert rc == 0
             assert event_reactor.get_queue().put.call_count == 1
             assert isinstance(
                 event_reactor.get_queue().put.call_args[0][0][0], JobQueued)


### PR DESCRIPTION
To pass with recent releases of flake8 et al.

The remaining style warnings `N803` are false-positives which will hopefully be resolved in a future patch release of `pep8-naming` (anything > 0.8.0).