### PR TITLE
fix sourcing empty workspace built with `--merge-install`

### DIFF
--- a/colcon_core/shell/template/prefix_util.py
+++ b/colcon_core/shell/template/prefix_util.py
@@ -38,6 +38,9 @@ def get_packages(prefix_path, merged_install):
     # must match colcon_core.location.get_relative_package_index_path()
     subdirectory = 'share/colcon-core/packages'
     if merged_install:
+        # return if workspace is empty
+        if not (prefix_path / subdirectory).is_dir():
+            return packages
         # find all files in the subdirectory
         for p in (prefix_path / subdirectory).iterdir():
             if not p.is_file():

--- a/test/test_shell_template_prefix_util.py
+++ b/test/test_shell_template_prefix_util.py
@@ -29,6 +29,10 @@ def test_get_packages():
     with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
         prefix_path = Path(prefix_path)
 
+        # mock no packages in not merged install layout
+        packages = get_packages(prefix_path, False)
+        assert packages == {}
+
         # mock packages in not merged install layout
         subdirectory = get_relative_package_index_path()
         for pkg_name in ('pkgA', 'pkgB'):
@@ -38,6 +42,10 @@ def test_get_packages():
         (prefix_path / 'dummy_dir').mkdir()
         (prefix_path / '.hidden_dir').mkdir()
         (prefix_path / 'dummy_file').write_text('')
+
+        # mock no packages in merged install layout
+        packages = get_packages(prefix_path, True)
+        assert packages == {}
 
         # mock packages in merged install layout
         (prefix_path / subdirectory).mkdir(parents=True)

--- a/test/test_shell_template_prefix_util.py
+++ b/test/test_shell_template_prefix_util.py
@@ -29,7 +29,7 @@ def test_get_packages():
     with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
         prefix_path = Path(prefix_path)
 
-        # mock no packages in not merged install layout
+        # check no packages in not merged install layout
         packages = get_packages(prefix_path, False)
         assert packages == {}
 
@@ -43,7 +43,7 @@ def test_get_packages():
         (prefix_path / '.hidden_dir').mkdir()
         (prefix_path / 'dummy_file').write_text('')
 
-        # mock no packages in merged install layout
+        # check no packages in merged install layout
         packages = get_packages(prefix_path, True)
         assert packages == {}
 


### PR DESCRIPTION
Before this patch:
```
$ docker run -it --rm osrf/ros2:nightly
mkdir -p /tmp/foo/src && cd /tmp/foo
colcon build --merge-install
source install/setup.bash

Traceback (most recent call last):
  File "/tmp/foo/install/_local_setup_util.py", line 137, in <module>
    main()
  File "/tmp/foo/install/_local_setup_util.py", line 18, in main
    packages = get_packages(Path(__file__).parent, args.merged_install)
  File "/tmp/foo/install/_local_setup_util.py", line 42, in get_packages
    for p in (prefix_path / subdirectory).iterdir():
  File "/usr/lib/python3.6/pathlib.py", line 1081, in iterdir
    for name in self._accessor.listdir(self):
  File "/usr/lib/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/foo/install/share/colcon-core/packages'
```

@karsten1987 FYI