### PR TITLE
Use env shebang for colcon script

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,9 @@ filterwarnings =
     error
 junit_suite_name = colcon-core
 
+[build_scripts]
+executable = /usr/bin/env python3
+
 [options.entry_points]
 colcon_core.argument_parser =
 colcon_core.environment =


### PR DESCRIPTION
Previously, when doing `colcon build` to make a python script, setup.py would run in the global environment, even if you have a virtualenv activated.

The script `colcon` now starts with the shebang `#!/usr/bin/env python3`, which causes the currently active colcon to run setup.py and whatever other scripts colcon invokes.