### PR TITLE
support pytest 5.0.0+ exit codes

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -154,12 +154,22 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         rc = await check_call(context, cmd, cwd=context.args.path, env=env)
 
         # use local import to avoid a dependency on pytest
-        from _pytest.main import EXIT_TESTSFAILED
+        try:
+            from _pytest.main import EXIT_TESTSFAILED
+        except ImportError:
+            # Support pytest 5.0.0 and above exit codes
+            from _pytest.main import ExitCode
+            EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
         if rc and rc.returncode == EXIT_TESTSFAILED:
             context.put_event_into_queue(
                 TestFailure(context.pkg.name))
 
-        from _pytest.main import EXIT_NOTESTSCOLLECTED
+        try:
+            from _pytest.main import EXIT_NOTESTSCOLLECTED
+        except ImportError:
+            # Support pytest 5.0.0 and above exit codes
+            from _pytest.main import ExitCode
+            EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
         if rc and rc.returncode not in (
             EXIT_NOTESTSCOLLECTED, EXIT_TESTSFAILED
         ):


### PR DESCRIPTION
Pytest moved their exit code to an Enum class named ExitCode in 5.0.0 and up: https://github.com/pytest-dev/pytest/commit/2b92fee1c315469c3f257673a508e51a1f1a6230#diff-7191acb1a6aaab2f77b6e53ce837e348

Without this change, colcon fails to run pytests with the following error:
```
[4.875s] ERROR:colcon.colcon_core.task.python.test:Exception in Python testing step extension 'pytest': cannot import name 'EXIT_TESTSFAILED'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/colcon_core/task/python/test/__init__.py", line 75, in test
    return await extension.step(self.context, env, setup_py_data)
  File "/usr/local/lib/python3.6/dist-packages/colcon_core/task/python/test/pytest.py", line 157, in step
    from _pytest.main import EXIT_TESTSFAILED
ImportError: cannot import name 'EXIT_TESTSFAILED'
```

Edit: AFAICT test failures appear unrelated to this change and are present on [master cron jobs](https://travis-ci.org/colcon/colcon-core/jobs/552574282)

Fixes #196.