### PR TITLE
support pytest 5.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,8 @@ exclude =
 [tool:pytest]
 filterwarnings =
     error
+    ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    ignore:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
 junit_suite_name = colcon-core
 
 [options.entry_points]

--- a/test/test_entry_point.py
+++ b/test/test_entry_point.py
@@ -117,7 +117,7 @@ def test_entry_point_blacklist():
         with pytest.raises(RuntimeError) as e:
             load_entry_point(entry_point)
         assert 'The entry point group name is listed in the environment ' \
-            'variable' in str(e)
+            'variable' in str(e.value)
     assert entry_point.load.call_count == 0
 
     # entry point listed in the blacklist can't be loaded
@@ -127,7 +127,7 @@ def test_entry_point_blacklist():
         with pytest.raises(RuntimeError) as e:
             load_entry_point(entry_point)
         assert 'The entry point name is listed in the environment variable' \
-            in str(e)
+            in str(e.value)
     assert entry_point.load.call_count == 0
 
 

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -148,13 +148,14 @@ def test_add_executor_arguments():
     ):
         with pytest.raises(AssertionError) as e:
             add_executor_arguments(parser)
-        assert 'Executor extensions must have unique priorities' in str(e)
+        assert 'Executor extensions must have unique priorities' in \
+            str(e.value)
 
     # no extensions
     with EntryPointContext():
         with pytest.raises(AssertionError) as e:
             add_executor_arguments(parser)
-        assert 'No executor extensions found' in str(e)
+        assert 'No executor extensions found' in str(e.value)
 
     # choose executor by environment variable
     with EntryPointContext(extension1=Extension1, extension2=Extension2):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -48,11 +48,11 @@ def test_get_numeric_log_level():
     # invalid string
     with pytest.raises(ValueError) as e:
         get_numeric_log_level('invalid')
-    assert str(e).endswith(
+    assert str(e.value).endswith(
         'valid names are: CRITICAL, ERROR, WARNING, INFO, DEBUG '
         '(case-insensitive)')
 
     # negative numeric
     with pytest.raises(ValueError) as e:
         get_numeric_log_level('-1')
-    assert str(e).endswith('numeric log levels must be positive')
+    assert str(e.value).endswith('numeric log levels must be positive')

--- a/test/test_package_descriptor.py
+++ b/test/test_package_descriptor.py
@@ -45,7 +45,7 @@ def test_get_dependencies():
 
     with pytest.raises(AssertionError) as e:
         d1.get_dependencies()
-    assert "'self'" in str(e)
+    assert "'self'" in str(e.value)
 
 
 def test_get_recursive_dependencies():

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -47,7 +47,8 @@ def test_identify():
         desc.name = 'other-name'
         with pytest.raises(RuntimeError) as e:
             extension.identify(desc)
-        assert str(e).endswith('Package name already set to different value')
+        assert str(e.value).endswith(
+            'Package name already set to different value')
 
         (basepath / 'setup.cfg').write_text(
             '[metadata]\n'

--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -155,13 +155,13 @@ def test_satisfies_version():
 
     with pytest.raises(RuntimeError) as e:
         satisfies_version('1.0.3', '^1.1')
-    assert 'too old' in str(e)
+    assert 'too old' in str(e.value)
 
     with pytest.raises(RuntimeError) as e:
         satisfies_version('2.0.0', '^1.2')
-    assert 'newer' in str(e)
+    assert 'newer' in str(e.value)
 
     # different semantic for version numbers before 1.0
     with pytest.raises(RuntimeError) as e:
         satisfies_version('0.2.3', '^0.1')
-    assert 'newer' in str(e)
+    assert 'newer' in str(e.value)

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -78,7 +78,7 @@ def test_get_command_environment():
                 with pytest.raises(RuntimeError) as e:
                     run_until_complete(coroutine)
         assert 'Could not find a shell extension for the command environment' \
-            in str(e)
+            in str(e.value)
         assert extensions[90]['extension1'].generate_command_environment \
             .call_count == 1
         # the raised exceptions are catched and result in a debug/info message
@@ -98,7 +98,7 @@ def test_get_command_environment():
         coroutine = get_command_environment(None, '/build/base', None)
         with pytest.raises(RuntimeError) as e:
             run_until_complete(coroutine)
-        assert str(e).endswith(': custom exception')
+        assert str(e.value) == 'custom exception'
         assert extensions[90]['extension1'].generate_command_environment \
             .call_count == 0
 
@@ -167,7 +167,7 @@ def test_create_environment_hook():
         # no primary shell extension
         with pytest.raises(RuntimeError) as e:
             create_environment_hook(None, None, None, None, None)
-        assert str(e).endswith(
+        assert str(e.value).endswith(
             'Could not find a primary shell extension for creating an '
             'environment hook')
 

--- a/test/test_shell_bat.py
+++ b/test/test_shell_bat.py
@@ -63,7 +63,7 @@ def _test_extension(prefix_path):
             coroutine = extension.generate_command_environment(
                 'task_name', prefix_path, {})
             run_until_complete(coroutine)
-        assert str(e).endswith('Not usable on non-Windows systems')
+        assert str(e.value).endswith('Not usable on non-Windows systems')
     else:
         # dependency script missing
         with pytest.raises(RuntimeError) as e:

--- a/test/test_shell_sh.py
+++ b/test/test_shell_sh.py
@@ -64,7 +64,7 @@ def _test_extension(prefix_path):
             coroutine = extension.generate_command_environment(
                 'task_name', prefix_path, {})
             run_until_complete(coroutine)
-        assert str(e).endswith('Not usable on Windows systems')
+        assert str(e.value).endswith('Not usable on Windows systems')
     else:
         # dependency script missing
         with pytest.raises(RuntimeError) as e:


### PR DESCRIPTION
This patch fixes #196 and addresses the failing CI due to the recent release of `pytest` 5.0. The change is backward compatible with older `pytest` versions.

* The first commit uses the new exit code constants.
* The second commit updates the use of the `ExceptionInfo` (which changes in pytest-dev/pytest#5412)
* The third commit ignores the new deprecation warnings.