### PR TITLE
[Windows] Use default expansion for _colcon_python_executable

### DIFF
--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -63,7 +63,7 @@ goto:eof
     :: use the Python executable known at configure time
     set "_colcon_python_executable=@(python_executable)"
     :: if it doesn't exist try a fall back
-    if not exist "!_colcon_python_executable!" (
+    if not exist "%_colcon_python_executable%" (
       python --version > NUL 2> NUL
       if errorlevel 1 (
         echo error: unable to find python executable


### PR DESCRIPTION
It seems to be a regression after https://github.com/colcon/colcon-core/pull/209, where it removed `enabledelayedexpansion` for `_colcon_run_ordered_commands` but forgot to revert the delay expansion usage. As a result, whenever the generated `local_setup.bat` runs, it throws out `error: unable to find python executable` even the Python executable exists.