### PR TITLE
Don't make bdist_egg

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -73,10 +73,6 @@ class PythonBuildTask(TaskExtensionPoint):
                 '--single-version-externally-managed',
             ]
             self._append_install_layout(args, cmd)
-            cmd += [
-                'bdist_egg', '--dist-dir', os.path.join(
-                    args.build_base, 'dist'),
-            ]
             rc = await check_call(self.context, cmd, cwd=args.path, env=env)
             if rc and rc.returncode:
                 return rc.returncode


### PR DESCRIPTION
Normally when running setup.py install, python makes a bdist egg, so we need to use the bdist_egg to control where it gets generated (outside the source tree).
But since we're using --single-version-externally-managed, this is no longer required.

Also added test coverage to ensure that my code is correct.

~~fixes #226~~
On third though, actually fixes #226