### PR TITLE
add COLCON_WARNINGS environment variable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ colcon_core.environment_variable =
     home = colcon_core.command:HOME_ENVIRONMENT_VARIABLE
     log_level = colcon_core.command:LOG_LEVEL_ENVIRONMENT_VARIABLE
     log_path = colcon_core.command:LOG_PATH_ENVIRONMENT_VARIABLE
+    warnings = colcon_core.command:WARNINGS_ENVIRONMENT_VARIABLE
 colcon_core.event_handler =
     console_direct = colcon_core.event_handler.console_direct:ConsoleDirectEventHandler
     console_start_end = colcon_core.event_handler.console_start_end:ConsoleStartEndEventHandler


### PR DESCRIPTION
This environment variable provide a way to specify warnings filter which are scoped to modules matching the regular expression `colcon.*`. Using `PYTHONWARNINGS` directly isn't possible since it doesn't support using a regular expression: see https://bugs.python.org/issue34624.