### PR TITLE
use non-deprecated logger API

### DIFF
--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -134,7 +134,7 @@ def create_dependency_descriptor(requirement_string):
             metadata['version_gte'] = version
             metadata['version_lt'] = _next_incompatible_version(version)
         else:
-            logger.warn(
+            logger.warning(
                 "Ignoring unknown symbol '{symbol}' in '{requirement}'"
                 .format_map(locals()))
     return DependencyDescriptor(requirement.name, metadata=metadata)


### PR DESCRIPTION
Detected using this new feature: colcon/colcon-core#232.