### PR TITLE
unlink existing symlink before writing evaluate template content to file

### DIFF
--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -38,6 +38,10 @@ def expand_template(template_path, destination_path, data):
         raise
     else:
         os.makedirs(str(destination_path.parent), exist_ok=True)
+        # if the destination_path is a symlink remove the symlink
+        # to avoid writing to the symlink destination
+        if destination_path.is_symlink():
+            destination_path.unlink()
         with destination_path.open('w') as h:
             h.write(output)
     finally:


### PR DESCRIPTION
Otherwise if the destination already exists and is a symlink the evaluated template will be written to the symlink instead of to the actual destination. Since changing the content of the symlinked file is undesired the symlink needs to be unlinked before.