### PR TITLE
Clarify new pytest version requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ tests_require =
   mock
   pep8-naming
   pylint
-  pytest
+  pytest>=3.9
   pytest-cov
   scspell3k>=2.2
 zip_safe = false


### PR DESCRIPTION
Introduced by #230.

Found when packaging for Fedora 29 and EPEL 7, which package pytest 3.6.4 and 2.9.2 respectively. I'll have to skip these tests on those platforms.

It is noteworthy that neither Bionic nor Cosmic meet this requirement either.