### PR TITLE
Fix crash when a shell extension crashes

### DIFF
--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -170,7 +170,7 @@ async def _async_check_call(
                 process,
                 # pseudo terminals need to be closed explicitly
                 stdout if use_pty else None, stderr if use_pty else None))
-        await asyncio.gather(*callbacks)
+        await asyncio.gather(*callbacks, return_exceptions=True)
 
     return process.returncode, output[0], output[1]
 

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -172,16 +172,7 @@ async def _async_check_call(
                 process,
                 # pseudo terminals need to be closed explicitly
                 stdout if use_pty else None, stderr if use_pty else None))
-        try:
-            done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
-        except CancelledError:
-            # finish the communication with the subprocess
-            done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
-            raise
-        finally:
-            # read potential exceptions to avoid asyncio errors
-            for task in done:
-                _ = task.exception()  # noqa: F841
+        await asyncio.gather(*callbacks)
 
     return process.returncode, output[0], output[1]
 

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -9,8 +9,6 @@ to maintain the original order as closely as possible.
 """
 
 import asyncio
-from concurrent.futures import ALL_COMPLETED
-from concurrent.futures import CancelledError
 from functools import partial
 import os
 import platform


### PR DESCRIPTION
Fix #138 
example of misbehavior:

colcon.colcon_core.shellFailed   <<< orocos_kdl [ Exited with code 1 ]                                                                                                                                                         ERROR Exception in shell extension 'bat': local variable 'done' referenced before assignment                                                                                                                                   Traceback (most recent call last):
  File "c:\python38\lib\site-packages\colcon_core\subprocess.py", line 176, in _async_check_call
    done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
  File "c:\python38\lib\asyncio\tasks.py", line 426, in wait
    return await _wait(fs, timeout, return_when, loop)
  File "c:\python38\lib\asyncio\tasks.py", line 523, in _wait
    await waiter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\python38\lib\site-packages\colcon_core\shell\__init__.py", line 275, in get_command_environment
    return await extension.generate_command_environment(
  File "c:\python38\lib\site-packages\colcon_core\shell\bat.py", line 123, in generate_command_environment
    env = await get_environment_variables(cmd, cwd=str(build_base))
  File "c:\python38\lib\site-packages\colcon_core\shell\__init__.py", line 312, in get_environment_variables
    output = await check_output(cmd, cwd=cwd, shell=shell)
  File "c:\python38\lib\site-packages\colcon_core\subprocess.py", line 104, in check_output
    rc, stdout_data, _ = await _async_check_call(
  File "c:\python38\lib\site-packages\colcon_core\subprocess.py", line 183, in _async_check_call
    for task in done:
UnboundLocalError: local variable 'done' referenced before assignment