### PR TITLE
avoid requiring tmp_path introduce in pytest 3.9.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ tests_require =
   mock
   pep8-naming
   pylint
-  pytest>=3.9
+  pytest
   pytest-cov
   scspell3k>=2.2
 zip_safe = false

--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -46,59 +46,56 @@ def monkey_patch_put_event_into_queue(monkeypatch):
     )
 
 
-@pytest.fixture
-def event_loop():
-    loop = new_event_loop()
-    asyncio.set_event_loop(loop)
-    yield loop
-    loop.close()
+def test_build_package():
+    event_loop = new_event_loop()
+    asyncio.set_event_loop(event_loop)
+    try:
+        with TemporaryDirectory(prefix='test_colcon_') as tmp_path_str:
+            tmp_path = Path(tmp_path_str)
+            python_build_task = PythonBuildTask()
+            package = PackageDescriptor(tmp_path / 'src')
+            package.name = 'test_package'
+            package.type = 'python'
 
+            context = TaskContext(
+                pkg=package,
+                args=SimpleNamespace(
+                    path=str(tmp_path / 'src'),
+                    build_base=str(tmp_path / 'build'),
+                    install_base=str(tmp_path / 'install'),
+                    symlink_install=False,
+                ),
+                dependencies={}
+            )
+            python_build_task.set_context(context=context)
 
-def test_build_package(event_loop):
-    with TemporaryDirectory(prefix='test_colcon_') as tmp_path_str:
-        tmp_path = Path(tmp_path_str)
-        python_build_task = PythonBuildTask()
-        package = PackageDescriptor(tmp_path / 'src')
-        package.name = 'test_package'
-        package.type = 'python'
+            pkg = python_build_task.context.pkg
 
-        context = TaskContext(
-            pkg=package,
-            args=SimpleNamespace(
-                path=str(tmp_path / 'src'),
-                build_base=str(tmp_path / 'build'),
-                install_base=str(tmp_path / 'install'),
-                symlink_install=False,
-            ),
-            dependencies={}
-        )
-        python_build_task.set_context(context=context)
+            pkg.path.mkdir()
+            (pkg.path / 'setup.py').write_text(
+                'from setuptools import setup\n'
+                'setup(\n'
+                '    name="test_package",\n'
+                '    packages=["my_module"],\n'
+                ')\n'
+            )
+            (pkg.path / 'my_module').mkdir()
+            (pkg.path / 'my_module' / '__init__.py').touch()
 
-        pkg = python_build_task.context.pkg
+            src_base = Path(python_build_task.context.args.path)
 
-        pkg.path.mkdir()
-        (pkg.path / 'setup.py').write_text(
-            'from setuptools import setup\n'
-            'setup(\n'
-            '    name="test_package",\n'
-            '    packages=["my_module"],\n'
-            ')\n'
-        )
-        (pkg.path / 'my_module').mkdir()
-        (pkg.path / 'my_module' / '__init__.py').touch()
+            source_files_before = set(src_base.rglob('*'))
+            event_loop.run_until_complete(python_build_task.build())
+            source_files_after = set(src_base.rglob('*'))
+            assert source_files_before == source_files_after
 
-        src_base = Path(python_build_task.context.args.path)
+            build_base = Path(python_build_task.context.args.build_base)
+            assert 1 == len(list(build_base.rglob('my_module/__init__.py')))
 
-        source_files_before = set(src_base.rglob('*'))
-        event_loop.run_until_complete(python_build_task.build())
-        source_files_after = set(src_base.rglob('*'))
-        assert source_files_before == source_files_after
+            install_base = Path(python_build_task.context.args.install_base)
+            assert 1 == len(list(install_base.rglob('my_module/__init__.py')))
 
-        build_base = Path(python_build_task.context.args.build_base)
-        assert 1 == len(list(build_base.rglob('my_module/__init__.py')))
-
-        install_base = Path(python_build_task.context.args.install_base)
-        assert 1 == len(list(install_base.rglob('my_module/__init__.py')))
-
-        pkg_info, = install_base.rglob('PKG-INFO')
-        assert 'Name: test-package' in pkg_info.read_text().splitlines()
+            pkg_info, = install_base.rglob('PKG-INFO')
+            assert 'Name: test-package' in pkg_info.read_text().splitlines()
+    finally:
+        event_loop.close()

--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -3,6 +3,7 @@
 
 import asyncio
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
 from colcon_core.package_descriptor import PackageDescriptor
@@ -46,24 +47,26 @@ def monkey_patch_put_event_into_queue(monkeypatch):
 
 
 @pytest.fixture
-def python_build_task(tmp_path):
-    task = PythonBuildTask()
-    package = PackageDescriptor(tmp_path / 'src')
-    package.name = 'test_package'
-    package.type = 'python'
+def python_build_task():
+    with TemporaryDirectory(prefix='test_colcon_') as tmp_path_str:
+        tmp_path = Path(tmp_path_str)
+        task = PythonBuildTask()
+        package = PackageDescriptor(tmp_path / 'src')
+        package.name = 'test_package'
+        package.type = 'python'
 
-    context = TaskContext(
-        pkg=package,
-        args=SimpleNamespace(
-            path=str(tmp_path / 'src'),
-            build_base=str(tmp_path / 'build'),
-            install_base=str(tmp_path / 'install'),
-            symlink_install=False,
-        ),
-        dependencies={}
-    )
-    task.set_context(context=context)
-    yield task
+        context = TaskContext(
+            pkg=package,
+            args=SimpleNamespace(
+                path=str(tmp_path / 'src'),
+                build_base=str(tmp_path / 'build'),
+                install_base=str(tmp_path / 'install'),
+                symlink_install=False,
+            ),
+            dependencies={}
+        )
+        task.set_context(context=context)
+        yield task
 
 
 @pytest.fixture

--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -47,10 +47,17 @@ def monkey_patch_put_event_into_queue(monkeypatch):
 
 
 @pytest.fixture
-def python_build_task():
+def event_loop():
+    loop = new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+def test_build_package(event_loop):
     with TemporaryDirectory(prefix='test_colcon_') as tmp_path_str:
         tmp_path = Path(tmp_path_str)
-        task = PythonBuildTask()
+        python_build_task = PythonBuildTask()
         package = PackageDescriptor(tmp_path / 'src')
         package.name = 'test_package'
         package.type = 'python'
@@ -65,44 +72,33 @@ def python_build_task():
             ),
             dependencies={}
         )
-        task.set_context(context=context)
-        yield task
+        python_build_task.set_context(context=context)
 
+        pkg = python_build_task.context.pkg
 
-@pytest.fixture
-def event_loop():
-    loop = new_event_loop()
-    asyncio.set_event_loop(loop)
-    yield loop
-    loop.close()
+        pkg.path.mkdir()
+        (pkg.path / 'setup.py').write_text(
+            'from setuptools import setup\n'
+            'setup(\n'
+            '    name="test_package",\n'
+            '    packages=["my_module"],\n'
+            ')\n'
+        )
+        (pkg.path / 'my_module').mkdir()
+        (pkg.path / 'my_module' / '__init__.py').touch()
 
+        src_base = Path(python_build_task.context.args.path)
 
-def test_build_package(python_build_task: PythonBuildTask, event_loop):
-    pkg = python_build_task.context.pkg
+        source_files_before = set(src_base.rglob('*'))
+        event_loop.run_until_complete(python_build_task.build())
+        source_files_after = set(src_base.rglob('*'))
+        assert source_files_before == source_files_after
 
-    pkg.path.mkdir()
-    (pkg.path / 'setup.py').write_text(
-        'from setuptools import setup\n'
-        'setup(\n'
-        '    name="test_package",\n'
-        '    packages=["my_module"],\n'
-        ')\n'
-    )
-    (pkg.path / 'my_module').mkdir()
-    (pkg.path / 'my_module' / '__init__.py').touch()
+        build_base = Path(python_build_task.context.args.build_base)
+        assert 1 == len(list(build_base.rglob('my_module/__init__.py')))
 
-    src_base = Path(python_build_task.context.args.path)
+        install_base = Path(python_build_task.context.args.install_base)
+        assert 1 == len(list(install_base.rglob('my_module/__init__.py')))
 
-    source_files_before = set(src_base.rglob('*'))
-    event_loop.run_until_complete(python_build_task.build())
-    source_files_after = set(src_base.rglob('*'))
-    assert source_files_before == source_files_after
-
-    build_base = Path(python_build_task.context.args.build_base)
-    assert 1 == len(list(build_base.rglob('my_module/__init__.py')))
-
-    install_base = Path(python_build_task.context.args.install_base)
-    assert 1 == len(list(install_base.rglob('my_module/__init__.py')))
-
-    pkg_info, = install_base.rglob('PKG-INFO')
-    assert 'Name: test-package' in pkg_info.read_text().splitlines()
+        pkg_info, = install_base.rglob('PKG-INFO')
+        assert 'Name: test-package' in pkg_info.read_text().splitlines()


### PR DESCRIPTION
Reverts #243 and avoids the use of `tmp_path` introduced by #230 instead.

Easier to read whitespace-ignoring diff: https://github.com/colcon/colcon-core/pull/246/files?w=1

@rotu FYI.