### PR TITLE
Add support for prepending multiple values to env variables from .dsv files

### DIFF
--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -256,22 +256,25 @@ def handle_dsv_types_except_source(type_, remainder, prefix):
         DSV_TYPE_PREPEND_NON_DUPLICATE,
         DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS
     ):
-        env_name, value = remainder.split(';', 1)
-        if not value:
-            value = prefix
-        elif not os.path.isabs(value):
-            value = os.path.join(prefix, value)
-        if (
-            type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and
-            not os.path.exists(value)
-        ):
-            comment = 'skip extending {env_name} with not existing path: ' \
-                '{value}'.format_map(locals())
-            if _include_comments():
-                commands.append(
-                    FORMAT_STR_COMMENT_LINE.format_map({'comment': comment}))
-        else:
-            commands += _prepend_unique_value(env_name, value)
+        env_name_and_values = remainder.split(';')
+        env_name = env_name_and_values[0]
+        values = env_name_and_values[1:]
+        if 0 == len(values):
+            values.append(prefix)
+        for value in values:
+            if not os.path.isabs(value):
+                value = os.path.join(prefix, value)
+            if (
+                type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and
+                not os.path.exists(value)
+            ):
+                comment = 'skip extending {env_name} with not existing path: ' \
+                    '{value}'.format_map(locals())
+                if _include_comments():
+                    commands.append(
+                        FORMAT_STR_COMMENT_LINE.format_map({'comment': comment}))
+            else:
+                commands += _prepend_unique_value(env_name, value)
     else:
         assert False, 'Unknown environment hook type: ' + type_
     return commands

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -258,11 +258,11 @@ def handle_dsv_types_except_source(type_, remainder, prefix):
     ):
         env_name_and_values = remainder.split(';')
         env_name = env_name_and_values[0]
-        values = list(filter(None, env_name_and_values[1:]))
-        if 0 == len(values):
-            values.append(prefix)
+        values = env_name_and_values[1:]
         for value in values:
-            if not os.path.isabs(value):
+            if not value:
+                value = prefix
+            elif not os.path.isabs(value):
                 value = os.path.join(prefix, value)
             if (
                 type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -258,7 +258,7 @@ def handle_dsv_types_except_source(type_, remainder, prefix):
     ):
         env_name_and_values = remainder.split(';')
         env_name = env_name_and_values[0]
-        values = env_name_and_values[1:]
+        values = list(filter(None, env_name_and_values[1:]))
         if 0 == len(values):
             values.append(prefix)
         for value in values:


### PR DESCRIPTION
To add context, when working with Java projects it can happen that a package produces multiple jar files that should be added to the `CLASSPATH` environment variable.
Example .dsv file for `rcljava_common`:

```
prepend-non-duplicate;CLASSPATH;share/rcljava_common/java/commons-lang3-3.7.jar;share/rcljava_common/java/slf4j-api-1.7.21.jar;share/rcljava_common/java/log4j-1.2.17.jar;share/rcljava_common/java/slf4j-log4j12-1.7.21.jar;share/rcljava_common/java/slf4j-jdk14-1.7.21.jar;share/rcljava_common/java/rcljava_common.jar
```