### PR TITLE
support more characters in environment variable names on Windows

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -7,6 +7,7 @@ import locale
 import os
 from pathlib import Path
 import re
+import sys
 import traceback
 import warnings
 
@@ -325,7 +326,13 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
                 "encoding '{encoding}': {line_replaced}".format_map(locals()))
             continue
         parts = line.split('=', 1)
-        if len(parts) == 2 and re.match('^[a-zA-Z0-9_%]+$', parts[0]):
+        if sys.platform != 'win32':
+            regex = '^[a-zA-Z_][a-zA-Z0-9_]*$'
+        else:
+            regex = '^[a-zA-Z0-9%' + ''.join(
+                '\\' + c for c in r'_(){}[]$*+-\/"#\',;.@!?'
+            ) + ']+$'
+        if len(parts) == 2 and re.match(regex, parts[0]):
             # add new environment variable
             env[parts[0]] = parts[1]
         else:

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -329,8 +329,8 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
         if sys.platform != 'win32':
             regex = '^[a-zA-Z_][a-zA-Z0-9_]*$'
         else:
-            regex = '^[a-zA-Z0-9%' + ''.join(
-                '\\' + c for c in r'_(){}[]$*+-\/"#\',;.@!?'
+            regex = '^[a-zA-Z0-9%_' + ''.join(
+                '\\' + c for c in r'(){}[]$*+-\/"#\',;.@!?'
             ) + ']+$'
         if len(parts) == 2 and re.match(regex, parts[0]):
             # add new environment variable


### PR DESCRIPTION
Fixes #248 

On Windows any of the following characters is allowed in an environment variable name (to my knowledge):
* lower alpha
* upper alpha
* digit
* underscore
* and the special characters not allowed on non-Windows:
  * percent (for dynamic names I guess)
  * `(){}[]$*+-\/"#',;.@!?`

For non-Windows the patch removes the `%` character (which was only added for Windows in the first place) as well as enforce that the first character is not a digit.