### PR TITLE
Always prepend with a trailing separator

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -89,7 +89,11 @@ class ShellExtensionPoint:
     """
     FORMAT_STR_INVOKE_SCRIPT = None
     """
-    The format string to remove a trailing separator from an environment variable.
+    The format string to remove a trailing separator.
+
+    When prepending to an environment variable, a trailing separator will be
+    left behind if the variable was not set previously.
+    This command is used to cleanup the trailing separarator.
 
     It must have the placeholder {name} for the environment variable name.
     This attribute is optionally defined in subclasses.

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -88,6 +88,13 @@ class ShellExtensionPoint:
     This attribute must be defined in a subclass.
     """
     FORMAT_STR_INVOKE_SCRIPT = None
+    """
+    The format string to remove a trailing separator from an environment variable.
+
+    It must have the placeholder {name} for the environment variable name.
+    This attribute is optionally defined in subclasses.
+    """
+    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = None
 
     def get_file_extensions(self):
         """

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -26,6 +26,7 @@ class BatShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '%{name}%'
     FORMAT_STR_INVOKE_SCRIPT = 'call:_colcon_prefix_bat_call_script ' \
         '"{script_path}"'
+    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = ':: TODO'
 
     def __init__(self):  # noqa: D107
         super().__init__()

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -26,7 +26,8 @@ class BatShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '%{name}%'
     FORMAT_STR_INVOKE_SCRIPT = 'call:_colcon_prefix_bat_call_script ' \
         '"{script_path}"'
-    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = ':: TODO'
+    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = 'echo %{name}%|' \
+        'findstr "%{value}%$" >NUL && set {name}=%{name}:~0,-1%'
 
     def __init__(self):  # noqa: D107
         super().__init__()

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -26,8 +26,8 @@ class BatShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '%{name}%'
     FORMAT_STR_INVOKE_SCRIPT = 'call:_colcon_prefix_bat_call_script ' \
         '"{script_path}"'
-    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = 'echo %{name}%|' \
-        'findstr "%{value}%$" >NUL && set {name}=%{name}:~0,-1%'
+    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if "%{name}:~-1%==";" ' \
+        'set {name}=%{name}:~0,-1%'
 
     def __init__(self):  # noqa: D107
         super().__init__()

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -26,8 +26,8 @@ class ShShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '${name}'
     FORMAT_STR_INVOKE_SCRIPT = 'COLCON_CURRENT_PREFIX="{prefix}" ' \
         '_colcon_prefix_sh_source_script "{script_path}"'
-    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = 'echo ${name} | ' \
-        'grep -q "{value}$" && export {name}=${{{name}%?}}'
+    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if test "$(echo -n ${name} | ' \
+        'tail -c 1)" = ":" ; then; export {name}=${{{name}%?}} ; fi'
 
     def __init__(self):  # noqa: D107
         super().__init__()
@@ -38,7 +38,6 @@ class ShShell(ShellExtensionPoint):
     def create_prefix_script(self, prefix_path, merge_install):  # noqa: D102
         prefix_env_path = prefix_path / 'local_setup.sh'
         logger.info("Creating prefix script '%s'" % prefix_env_path)
-
         expand_template(
             Path(__file__).parent / 'template' / 'prefix.sh.em',
             prefix_env_path,

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -26,6 +26,8 @@ class ShShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '${name}'
     FORMAT_STR_INVOKE_SCRIPT = 'COLCON_CURRENT_PREFIX="{prefix}" ' \
         '_colcon_prefix_sh_source_script "{script_path}"'
+    FORMAT_STR_CLEANUP_TRAILING_SEPARATORS = 'echo ${name} | ' \
+        'grep -q "{value}$" && export {name}=${{{name}%?}}'
 
     def __init__(self):  # noqa: D107
         super().__init__()
@@ -36,6 +38,7 @@ class ShShell(ShellExtensionPoint):
     def create_prefix_script(self, prefix_path, merge_install):  # noqa: D102
         prefix_env_path = prefix_path / 'local_setup.sh'
         logger.info("Creating prefix script '%s'" % prefix_env_path)
+
         expand_template(
             Path(__file__).parent / 'template' / 'prefix.sh.em',
             prefix_env_path,

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -16,12 +16,7 @@ FORMAT_STR_SET_ENV_VAR = '@(shell_extension.FORMAT_STR_SET_ENV_VAR)'
 FORMAT_STR_USE_ENV_VAR = '@(shell_extension.FORMAT_STR_USE_ENV_VAR)'
 @{assert shell_extension.FORMAT_STR_INVOKE_SCRIPT is not None}@
 FORMAT_STR_INVOKE_SCRIPT = '@(shell_extension.FORMAT_STR_INVOKE_SCRIPT)'
-
-@[if hasattr(shell_extension, 'FORMAT_STR_REMOVE_TRAILING_SEPARATOR')]@
 FORMAT_STR_REMOVE_TRAILING_SEPARATOR = '@(shell_extension.FORMAT_STR_REMOVE_TRAILING_SEPARATOR)'
-@[else]@
-FORMAT_STR_REMOVE_TRAILING_SEPARATOR = None
-@[end if]@
 
 DSV_TYPE_PREPEND_NON_DUPLICATE = 'prepend-non-duplicate'
 DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS = 'prepend-non-duplicate-if-exists'

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -192,7 +192,6 @@ def get_commands(pkg_name, prefix, primary_extension, additional_extension):
     if os.path.exists(package_dsv_path):
         commands += process_dsv_file(
             package_dsv_path, prefix, primary_extension, additional_extension)
-
     return commands
 
 

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -323,6 +323,9 @@ def _remove_trailing_separators():
     global env_state
     commands = []
     for name in env_state:
+        # skip variables that already had values before this script started prepending
+        if name in os.environ:
+            continue
         commands += [FORMAT_STR_REMOVE_TRAILING_SEPARATOR.format_map(
             {'name': name})]
     return commands

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -299,6 +299,9 @@ def _prepend_unique_value(name, value):
             env_state[name] = set()
         if os.environ.get(name):
             env_state[name] = set(os.environ[name].split(os.pathsep))
+    # prepend even if the variable has not been set yet, in case a shell script sets the
+    # same variable without the knowledge of this Python script.
+    # later _remove_trailing_separators() will cleanup any unintentional trailing separator
     extend = os.pathsep + FORMAT_STR_USE_ENV_VAR.format_map({'name': name})
     line = FORMAT_STR_SET_ENV_VAR.format_map(
         {'name': name, 'value': value + extend})

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -43,21 +43,21 @@ def main(argv=sys.argv[1:]):  # noqa: D103
     packages = get_packages(Path(__file__).parent, args.merged_install)
 
     ordered_packages = order_packages(packages)
-    commands = []
     for pkg_name in ordered_packages:
         if _include_comments():
-            commands += [FORMAT_STR_COMMENT_LINE.format_map(
-                {'comment': 'Package: ' + pkg_name})]
+            print(
+                FORMAT_STR_COMMENT_LINE.format_map(
+                    {'comment': 'Package: ' + pkg_name}))
         prefix = os.path.abspath(os.path.dirname(__file__))
         if not args.merged_install:
             prefix = os.path.join(prefix, pkg_name)
-        commands += get_commands(
+        for line in get_commands(
             pkg_name, prefix, args.primary_extension,
-            args.additional_extension)
+            args.additional_extension
+        ):
+            print(line)
 
-    commands += _remove_trailing_separators()
-
-    for line in commands:
+    for line in _remove_trailing_separators():
         print(line)
 
 


### PR DESCRIPTION
This resolves an issue where environment variables can collide if modified by both .dsv files and scripts.
For more detail see https://github.com/ament/ament_package/issues/103

The solution is to always prepend, which will avoid overwriting a variable if previously set by a script.
Then we introduce a cleanup command for each variable prepended to in order to remove a possible trailing separator.

I've implemented the new "trailing separator cleanup" command for sh. Opening this PR for early feedback while I figure out the equivalent bat and powershell commands.

Open to better naming suggestions.