### PR TITLE
use a plain str where sufficient

### DIFF
--- a/colcon_core/topological_order.py
+++ b/colcon_core/topological_order.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 from collections import OrderedDict
-import copy
 
 from colcon_core.package_decorator import PackageDecorator
 
@@ -30,7 +29,7 @@ def topological_order_packages(
         d = _PackageDependencies(
             descriptor=descriptor,
             recursive_dependencies=rec_deps,
-            remaining_dependencies=copy.deepcopy(rec_deps),
+            remaining_dependencies={d.name for d in rec_deps},
         )
         queued.add(d)
 


### PR DESCRIPTION
Refactoring a set of `DependencyDescriptor`s to a set of `str` were sufficient.

For an example ROS 2 workspace with 268 pkgs the time to list goes down by roughly 10% (from 2s to 1.8s).