### PR TITLE
fix command to remove trailing separator

### DIFF
--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -26,8 +26,8 @@ class ShShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '${name}'
     FORMAT_STR_INVOKE_SCRIPT = 'COLCON_CURRENT_PREFIX="{prefix}" ' \
         '_colcon_prefix_sh_source_script "{script_path}"'
-    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if test "$(echo -n ${name} | ' \
-        'tail -c 1)" = ":" ; then; export {name}=${{{name}%?}} ; fi'
+    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if [ "$(echo -n ${name} | ' \
+        'tail -c 1)" = ":" ]; then export {name}=${{{name}%?}} ; fi'
 
     def __init__(self):  # noqa: D107
         super().__init__()


### PR DESCRIPTION
Follow up of #254 fixing the logic in sh/bash.