### PR TITLE
fix setting log base path

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -76,7 +76,7 @@ HOME_ENVIRONMENT_VARIABLE = EnvironmentVariable(
 """Environment variable to set the log directory"""
 LOG_PATH_ENVIRONMENT_VARIABLE = EnvironmentVariable(
     'COLCON_LOG_PATH',
-    'Set the log directory (default: $COLCON_HOME/log, to disable: '
+    'Set the log directory (default: ./log, to disable: '
     '{os.devnull})'.format_map(locals()))
 
 
@@ -264,8 +264,7 @@ def add_log_level_argument(parser):
     """
     parser.add_argument(
         '--log-base',
-        default='log',
-        help='The base path for all log directories (default: log, to '
+        help='The base path for all log directories (default: ./log, to '
              'disable: {os.devnull})'.format_map(globals()))
     parser.add_argument(
         '--log-level', action=LogLevelAction,

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -70,7 +70,10 @@ def get_log_path():
     path = None
     if _log_base_path is not None:
         path = _log_base_path
-    elif _log_base_path_env_var is not None:
+    elif (
+        _log_base_path_env_var is not None and
+        _log_base_path_env_var in os.environ
+    ):
         path = os.environ.get(_log_base_path_env_var)
     else:
         global _log_base_path_default

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -72,7 +72,7 @@ def get_log_path():
         path = _log_base_path
     elif (
         _log_base_path_env_var is not None and
-        _log_base_path_env_var in os.environ
+        os.environ.get(_log_base_path_env_var)
     ):
         path = os.environ.get(_log_base_path_env_var)
     else:

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -12,6 +12,7 @@ logger = colcon_logger.getChild(__name__)
 _config_path = None
 _config_path_env_var = None
 _log_base_path = None
+_log_base_path_default = None
 _log_base_path_env_var = None
 _log_subdirectory = None
 
@@ -64,23 +65,26 @@ def get_log_path():
     :returns: The base path for logging or None if logging is disabled
     :rtype: Path or None
     """
+    global _log_base_path
     global _log_base_path_env_var
     path = None
-    if _log_base_path_env_var is not None:
-        path = os.environ.get(_log_base_path_env_var)
-        if path == os.devnull:
-            return None
-        if path:
-            path = Path(str(path))
-    global _log_base_path
-    if not path:
-        assert _log_base_path is not None
+    if _log_base_path is not None:
         path = _log_base_path
-    path /= _log_subdirectory
-    return path
+    elif _log_base_path_env_var is not None:
+        path = os.environ.get(_log_base_path_env_var)
+    else:
+        global _log_base_path_default
+        path = _log_base_path_default
+
+    if path == os.devnull:
+        return None
+
+    return Path(str(path)) / _log_subdirectory
 
 
-def set_default_log_path(*, base_path, env_var=None, subdirectory=None):
+def set_default_log_path(
+    *, base_path, env_var=None, subdirectory=None, default='log'
+):
     """
     Set the base path for logging.
 
@@ -93,11 +97,15 @@ def set_default_log_path(*, base_path, env_var=None, subdirectory=None):
     :param str env_var: The name of the environment variable
     :param str subdirectory: The name of the subdirectory, if not provided a
       random uuid will be used instead
+    :param default: The default base path if the passed base path is None and
+      the environment variable is not set
     """
     global _log_base_path
+    global _log_base_path_default
     global _log_base_path_env_var
     global _log_subdirectory
-    _log_base_path = Path(str(base_path))
+    _log_base_path = base_path
+    _log_base_path_default = default
     _log_base_path_env_var = env_var
     assert subdirectory is None or subdirectory
     _log_subdirectory = subdirectory \

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -67,9 +67,15 @@ def test_log_path():
         base_path=log_base_path, env_var=log_base_path_env_var)
     assert isinstance(get_log_path(), Path)
     assert str(get_log_path().parent) == log_base_path
+    # use explicitly passed log base path even if environment variable is set
+    with EnvironmentContext(**{log_base_path_env_var: '/not/used'}):
+        assert isinstance(get_log_path(), Path)
+        assert str(get_log_path().parent) == log_base_path
 
-    # use environment variable when set
+    # use environment variable when set and no base path passed
     log_base_path = '/other/path'.replace('/', os.sep)
+    set_default_log_path(
+        base_path=None, env_var=log_base_path_env_var)
     with EnvironmentContext(**{log_base_path_env_var: log_base_path}):
         assert isinstance(get_log_path(), Path)
         assert str(get_log_path().parent) == log_base_path


### PR DESCRIPTION
The patch fixes #263 which reports a few problems around the logging base path:
* `COLCON_LOG_PATH` is consider when `--log-base` is not passed explicitly
* `--log-base` supports passing `os.devnull`
* the docs of `COLCON_LOG_PATH` state the correct default value which is supposed to be `./log`

It also updates the test to check explicitly for the desired precedence order.