### PR TITLE
remove unused COLCON_LOG_PATH env var

### DIFF
--- a/bin/colcon
+++ b/bin/colcon
@@ -37,7 +37,6 @@ entry_point.load_entry_points = custom_load_entry_points
 
 from colcon_core.command import HOME_ENVIRONMENT_VARIABLE  # noqa: E402 I202
 from colcon_core.command import LOG_LEVEL_ENVIRONMENT_VARIABLE  # noqa: E402
-from colcon_core.command import LOG_PATH_ENVIRONMENT_VARIABLE  # noqa: E402
 from colcon_core.entry_point \
     import EXTENSION_BLACKLIST_ENVIRONMENT_VARIABLE  # noqa: E402
 from colcon_core.environment.path import PathEnvironment  # noqa: E402
@@ -85,7 +84,6 @@ custom_entry_points.update({
         'extension_blacklist': EXTENSION_BLACKLIST_ENVIRONMENT_VARIABLE,
         'home': HOME_ENVIRONMENT_VARIABLE,
         'log_level': LOG_LEVEL_ENVIRONMENT_VARIABLE,
-        'log_path': LOG_PATH_ENVIRONMENT_VARIABLE,
     },
     'colcon_core.event_handler': {
         'console_direct': ConsoleDirectEventHandler,

--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -73,12 +73,6 @@ HOME_ENVIRONMENT_VARIABLE = EnvironmentVariable(
     'COLCON_HOME',
     'Set the configuration directory (default: ~/.colcon)')
 
-"""Environment variable to set the log directory"""
-LOG_PATH_ENVIRONMENT_VARIABLE = EnvironmentVariable(
-    'COLCON_LOG_PATH',
-    'Set the log directory (default: ./log, to disable: '
-    '{os.devnull})'.format_map(locals()))
-
 
 def main(*, command_name='colcon', argv=None):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,6 @@ colcon_core.environment_variable =
     extension_blacklist = colcon_core.entry_point:EXTENSION_BLACKLIST_ENVIRONMENT_VARIABLE
     home = colcon_core.command:HOME_ENVIRONMENT_VARIABLE
     log_level = colcon_core.command:LOG_LEVEL_ENVIRONMENT_VARIABLE
-    log_path = colcon_core.command:LOG_PATH_ENVIRONMENT_VARIABLE
     warnings = colcon_core.command:WARNINGS_ENVIRONMENT_VARIABLE
 colcon_core.event_handler =
     console_direct = colcon_core.event_handler.console_direct:ConsoleDirectEventHandler


### PR DESCRIPTION
This environment variable was never actually used / checked. Since the log directory is only created after the arguments have been passed the existing `--log-base` argument can be used in all cases.