### PR TITLE
fix environment for symlinked Python package which have their sources in a subdirectory

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -50,7 +50,7 @@ class PythonBuildTask(TaskExtensionPoint):
         python_lib = os.path.join(
             args.install_base, self._get_python_lib(args))
         os.makedirs(python_lib, exist_ok=True)
-        # and being in the  PYTHONPATH
+        # and being in the PYTHONPATH
         env = dict(env)
         env['PYTHONPATH'] = python_lib + os.pathsep + \
             env.get('PYTHONPATH', '')
@@ -105,9 +105,15 @@ class PythonBuildTask(TaskExtensionPoint):
             # to maintain the desired order
             if additional_hooks is None:
                 additional_hooks = []
+            base_path = args.build_base
+            # if the Python packages are in a subdirectory
+            # that needs to be appended to the build directory
+            package_dir = setup_py_data.get('package_dir') or {}
+            if '' in package_dir:
+                base_path = os.path.join(base_path, package_dir[''])
             additional_hooks += create_environment_hook(
-                'pythonpath_develop', Path(args.build_base), pkg.name,
-                'PYTHONPATH', args.build_base, mode='prepend')
+                'pythonpath_develop', Path(base_path), pkg.name, 'PYTHONPATH',
+                base_path, mode='prepend')
 
         hooks = create_environment_hooks(args.install_base, pkg.name)
         create_environment_scripts(


### PR DESCRIPTION
#219 introduced a regression for Python packages which don't store their first level Python package in a direct subdirectory below the `setup.py` file (it passes something like this in the `setup()` function: `package_dir={'': 'somewhere'}`).

When building with `--symlink-install` the `easy-install.pth` file (which was removed by the referenced PR) made sure that the Python package was found in the source directory of the package. With it being removed the fallback was used which is the `build` directory being part of the `PYTHONPATH`.

For packages as described above that `PYTHONPATH` entry pointing to the packages build directory is incorrect. It needs to point to the subdirectory from where the Python packages can be found - in the above example that would be `<pkg-build>/somewhere`.