### PR TITLE
catch KeyboardInterrupt before verb is invoked

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -95,6 +95,13 @@ def main(*, command_name='colcon', argv=None):
     :param list argv: The list of arguments
     :returns: The return code
     """
+    try:
+        return _main(command_name=command_name, argv=argv)
+    except KeyboardInterrupt:
+        return signal.SIGINT
+
+
+def _main(*, command_name, argv):
     global colcon_logger
     # default log level
     colcon_logger.setLevel(logging.WARNING)
@@ -474,8 +481,6 @@ def verb_main(context, logger):
     try:
         # catch exceptions raised in verb extension
         rc = context.args.main(context=context)
-    except KeyboardInterrupt:
-        rc = signal.SIGINT
     except RuntimeError as e:  # noqa: F841
         # only log the error message for "known" exceptions
         logger.error(

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -75,6 +75,12 @@ def test_main():
                 # therefore only try to delete the temporary directory
                 shutil.rmtree(log_base, ignore_errors=True)
 
+        # catch KeyboardInterrupt and return SIGINT error code
+        with patch('colcon_core.command._main', return_value=0) as _main:
+            _main.side_effect = KeyboardInterrupt()
+            rc = main()
+            assert rc == signal.SIGINT
+
 
 def test_create_parser():
     with EntryPointContext():
@@ -115,12 +121,6 @@ def test_verb_main():
     context = CommandContext(command_name='command_name', args=args)
     rc = verb_main(context, logger)
     assert rc == args.main.return_value
-    logger.error.assert_not_called()
-
-    # catch KeyboardInterrupt and return SIGINT error code
-    args.main.side_effect = KeyboardInterrupt()
-    rc = verb_main(context, logger)
-    assert rc == signal.SIGINT
     logger.error.assert_not_called()
 
     # catch RuntimeError and output error message


### PR DESCRIPTION
Otherwise hitting Ctrl-C before the verb execution has started results in a stacktrace.