### PR TITLE
Add missing quotation mark

### DIFF
--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -26,7 +26,7 @@ class BatShell(ShellExtensionPoint):
     FORMAT_STR_USE_ENV_VAR = '%{name}%'
     FORMAT_STR_INVOKE_SCRIPT = 'call:_colcon_prefix_bat_call_script ' \
         '"{script_path}"'
-    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if "%{name}:~-1%==";" ' \
+    FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if "%{name}:~-1%"==";" ' \
         'set {name}=%{name}:~0,-1%'
 
     def __init__(self):  # noqa: D107


### PR DESCRIPTION
Otherwise, calling setup.bat will result in multiple errors like the following:

    " set CMAKE_PREFIX_PATH=C:\J\workspace\packaging_windows\ws\install
    was unexpected at this time.

I guess some users may not have noticed if they were still using an
older version of colcon-core.