### PR TITLE
apply realpath only for deduplication, keep original path for UI

### DIFF
--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from copy import deepcopy
+import os
 from pathlib import Path
 
 from colcon_core.dependency_descriptor import DependencyDescriptor
@@ -13,7 +14,7 @@ class PackageDescriptor:
     A descriptor for a package.
 
     A packages is identified by the following triplet:
-    * the 'path' which must be a realpath
+    * the 'path' which must be an existing path
     * the 'type' which must be a non-empty string
     * the 'name' which must be a non-empty string
 
@@ -47,6 +48,11 @@ class PackageDescriptor:
         # IDEA category specific hooks
         self.hooks = []
         self.metadata = {}
+
+    @property
+    def realpath(self):
+        """Resolve the realpath of the package path."""
+        return os.path.realpath(str(self.path))
 
     def identifies_package(self):
         """
@@ -132,11 +138,11 @@ class PackageDescriptor:
         return dependencies
 
     def __hash__(self):  # noqa: D105
-        return hash((self.path, self.type, self.name))
+        return hash((self.realpath, self.type, self.name))
 
     def __eq__(self, other):  # noqa: D105
-        return (self.path, self.type, self.name) == \
-            (other.path, other.type, other.name)
+        return (self.realpath, self.type, self.name) == \
+            (other.realpath, other.type, other.name)
 
     def __str__(self):  # noqa: D105
         return '{' + ', '.join(

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -58,7 +58,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
             visited_paths.add(real_path)
 
             try:
-                result = identify(identification_extensions, real_path)
+                result = identify(identification_extensions, path)
             except IgnoreLocationException:
                 continue
             if result:

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -36,9 +36,9 @@ def test_has_parameters():
 
 
 def identify(_, path):
-    if path == os.path.realpath('/empty/path'):
+    if path == '/empty/path':
         return None
-    if path == os.path.realpath('/skip/path'):
+    if path == '/skip/path':
         raise IgnoreLocationException()
     return PackageDescriptor(path)
 


### PR DESCRIPTION
Instead of showing the user the realpath this change only uses the realpath for the de-duplication of found package descriptors. Package paths shown by e.g. `colcon list` show a more intuitive path like `src/pkgname` rather than an absolute path or even a path outside the workspace after resolving symlinks.