### PR TITLE
use CancelledError from asyncio instead of concurrent.futures for Python 3.8

### DIFF
--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from concurrent.futures import CancelledError
+from asyncio import CancelledError
 from enum import Enum
 import inspect
 import os

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -1,8 +1,8 @@
 # Copyright 2016-2019 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from asyncio import CancelledError
 from collections import OrderedDict
-from concurrent.futures import CancelledError
 import locale
 import os
 from pathlib import Path

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -10,7 +10,6 @@ to maintain the original order as closely as possible.
 
 import asyncio
 from concurrent.futures import ALL_COMPLETED
-from concurrent.futures import CancelledError
 from functools import partial
 import os
 import platform
@@ -174,7 +173,7 @@ async def _async_check_call(
                 stdout if use_pty else None, stderr if use_pty else None))
         try:
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
-        except CancelledError:
+        except asyncio.CancelledError:
             # finish the communication with the subprocess
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
             raise

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 from argparse import ArgumentParser
-from concurrent.futures import CancelledError
+from asyncio import CancelledError
 
 from colcon_core.event.job import JobEnded
 from colcon_core.event.job import JobQueued

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import asyncio
-from concurrent.futures import CancelledError
 import sys
 
 from colcon_core.subprocess import check_output
@@ -93,7 +92,7 @@ def test_run_cancel():
     task = asyncio.Task(coroutine, loop=loop)
     assert task.cancel() is True
     try:
-        with pytest.raises(CancelledError):
+        with pytest.raises(asyncio.CancelledError):
             loop.run_until_complete(task)
     finally:
         loop.close()


### PR DESCRIPTION
As of Python 3.8 the `asyncio` `CancelledError` is not the same as the one from `concurrent.futures` anymore.

I think this addresses the same problem as #245 for the `subprocess` modules but also the same issue in the `executor` module.