### PR TITLE
add more Python versions to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: python
-python: "3.5"
-dist: trusty
-sudo: true
+dist: xenial
+sudo: false
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 env:
   - TEST_SUITE=pytest
   - TEST_SUITE=bootstrap

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 version: '{build}'
+image: Visual Studio 2019
 environment:
   matrix:
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python39-x64"
 install:
   # avoid warnings which could also be suppressed with --no-warn-script-location
   - set "PATH=%PYTHON%\Scripts;%PATH%"


### PR DESCRIPTION
* On Linux check: Python 3.5 - 3.8 (all used by actively supported distros)
* On Windows (since it is a rolling release) only check the latest: Python 3.8