### PR TITLE
fix test to raise asyncio.CancelledError

### DIFF
--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -35,7 +35,7 @@ class Task:
         pass
 
     async def __call__(self, *args, **kwargs):
-        if isinstance(self.return_value, Exception):
+        if isinstance(self.return_value, BaseException):
             raise self.return_value
         return self.return_value
 


### PR DESCRIPTION
Follow up of #284 

`asyncio.CancelledError` is not an `Exception` but only a `BaseException`.