### PR TITLE
wrap default value to distinguish from explicitly passed arguments

### DIFF
--- a/colcon_core/argument_default.py
+++ b/colcon_core/argument_default.py
@@ -49,7 +49,6 @@ def wrap_default_value(value):
     if is_default_value(value):
         raise ValueError(
             'the passed value is already wrapped: ' + str(type(value)))
-        return value
     if type(value) in _types:
         return _types[type(value)](value)
     return value

--- a/colcon_core/argument_default.py
+++ b/colcon_core/argument_default.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+
+class BooleanDefaultValue:
+    """Boolean value distinguishable from explicitly passed arguments."""
+
+    def __init__(self, value):  # noqa: D107
+        assert isinstance(value, bool)
+        self._value = value
+
+    def __bool__(self):  # noqa: D105
+        return self._value
+
+
+class ListDefaultValue(list):
+    """List value distinguishable from explicitly passed arguments."""
+
+    pass
+
+
+class StringDefaultValue(str):
+    """String value distinguishable from explicitly passed arguments."""
+
+    pass
+
+
+_types = {
+    bool: BooleanDefaultValue,
+    list: ListDefaultValue,
+    str: StringDefaultValue,
+}
+
+
+def wrap_default_value(value):
+    """
+    Wrap a default value in a custom type.
+
+    The custom type makes the default value distinguishable from explicitly
+    passed arguments independent of the value.
+    The custom types try to match the behavior of the original type as much as
+    possible.
+
+    :param value: The default value to be wrapped
+    :returns: The wrapped value if the value type is supported, otherwise the
+      passed value
+    """
+    global _types
+    if is_default_value(value):
+        assert False
+        return value
+    if type(value) in _types:
+        return _types[type(value)](value)
+    return value
+
+
+def is_default_value(value):
+    """Check if a value is a default value."""
+    global _types
+    return isinstance(value, tuple(_types.values()))

--- a/colcon_core/argument_default.py
+++ b/colcon_core/argument_default.py
@@ -47,7 +47,8 @@ def wrap_default_value(value):
     """
     global _types
     if is_default_value(value):
-        assert False
+        raise ValueError(
+            'the passed value is already wrapped: ' + str(type(value)))
         return value
     if type(value) in _types:
         return _types[type(value)](value)

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -1,10 +1,12 @@
-# Copyright 2016-2018 Dirk Thomas
+# Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
 from glob import glob
 import os
 import sys
 
+from colcon_core.argument_default import is_default_value
+from colcon_core.argument_default import wrap_default_value
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
@@ -30,13 +32,14 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
             '--paths',
             nargs='*' if not single_path else '?',
             metavar='PATH',
-            default='.' if with_default else None,
+            default=wrap_default_value(['.']) if with_default else None,
             help='The paths to check for a package. Use shell wildcards '
                  '(e.g. `src/*`) to select all direct subdirectories' +
                  (' (default: .)' if with_default else ''))
 
     def has_parameters(self, *, args):  # noqa: D102
-        return bool(args.paths)
+        return not is_default_value(args.paths) and \
+            bool(args.paths)
 
     def discover(self, *, args, identification_extensions):  # noqa: D102
         if args.paths is None:


### PR DESCRIPTION
Together with the referenced PRs this addresses #274.

Add concept of wrapped default values in order to distinguish them from explicitly passed arguments. The wrapped values aim to have as similar behavior as possible to the original value type.