### PR TITLE
Extend shell extension point for environment variable populate.

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -253,6 +253,24 @@ class ShellExtensionPoint:
         """
         raise NotImplementedError()
 
+    def create_hook_populate_environment(
+        self, env_hook_name, prefix_path, pkg_name, env_dest, env_src
+    ):
+        """
+        Create a hook script to populate an environment variable from an existing one.
+
+        This method must be overridden in a subclass.
+
+        :param str env_hook_name: The name of the hook script
+        :param Path prefix_path: The path of the install prefix
+        :param str pkg_name: The package name
+        :param str env_dest: The name of the destination environment variable
+        :param str env_src: The name of the source environment variable
+        :returns: The relative path to the created hook script
+        :rtype: Path
+        """
+        raise NotImplementedError()
+
 
 def get_shell_extensions():
     """

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -257,8 +257,7 @@ class ShellExtensionPoint:
         self, env_hook_name, prefix_path, pkg_name, env_dest, env_src
     ):
         """
-        Create a hook script to populate an environment variable from an
-        existing one.
+        Create a hook script to populate new environment variable.
 
         This method must be overridden in a subclass.
 

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -257,7 +257,8 @@ class ShellExtensionPoint:
         self, env_hook_name, prefix_path, pkg_name, env_dest, env_src
     ):
         """
-        Create a hook script to populate an environment variable from an existing one.
+        Create a hook script to populate an environment variable from an
+        existing one.
 
         This method must be overridden in a subclass.
 

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -134,3 +134,14 @@ class BatShell(ShellExtensionPoint):
                 h.write('{key}={value}\n'.format_map(locals()))
 
         return env
+
+    def create_hook_populate_environment(
+        self, env_hook_name, prefix_path, pkg_name, , env_dest, env_src,
+    ):  # noqa: D102
+        hook_path = prefix_path / 'share' / pkg_name / 'hook' / \
+            ('%s.bat' % env_hook_name)
+        logger.info("Creating environment hook '%s'" % hook_path)
+        expand_template(
+            Path(__file__).parent / 'template' / 'hook_set_value.bat.em',
+            hook_path, {'name': env_dest, 'value': "%%%s%%" % env_src})
+        return hook_path

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -143,5 +143,5 @@ class BatShell(ShellExtensionPoint):
         logger.info("Creating environment hook '%s'" % hook_path)
         expand_template(
             Path(__file__).parent / 'template' / 'hook_set_value.bat.em',
-            hook_path, {'name': env_dest, 'value': "%%%s%%" % env_src})
+            hook_path, {'name': env_dest, 'value': '%%%s%%' % env_src})
         return hook_path

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -136,7 +136,7 @@ class BatShell(ShellExtensionPoint):
         return env
 
     def create_hook_populate_environment(
-        self, env_hook_name, prefix_path, pkg_name, , env_dest, env_src,
+        self, env_hook_name, prefix_path, pkg_name, env_dest, env_src,
     ):  # noqa: D102
         hook_path = prefix_path / 'share' / pkg_name / 'hook' / \
             ('%s.bat' % env_hook_name)

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -144,5 +144,5 @@ class ShShell(ShellExtensionPoint):
         logger.info("Creating environment hook '%s'" % hook_path)
         expand_template(
             Path(__file__).parent / 'template' / 'hook_set_value.sh.em',
-            hook_path, {'name': env_dest, 'value': "$%s" % env_src})
+            hook_path, {'name': env_dest, 'value': '$%s' % env_src})
         return hook_path

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -135,3 +135,14 @@ class ShShell(ShellExtensionPoint):
                 h.write('{key}={value}\n'.format_map(locals()))
 
         return env
+
+    def create_hook_populate_environment(
+        self, env_hook_name, prefix_path, pkg_name, env_dest, env_src,
+    ):  # noqa: D102
+        hook_path = prefix_path / 'share' / pkg_name / 'hook' / \
+            ('%s.sh' % env_hook_name)
+        logger.info("Creating environment hook '%s'" % hook_path)
+        expand_template(
+            Path(__file__).parent / 'template' / 'hook_set_value.sh.em',
+            hook_path, {'name': env_dest, 'value': "$%s" % env_src})
+        return hook_path

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -47,6 +47,8 @@ def test_extension_interface():
         extension.create_hook_prepend_value(None, None, None, None, None)
     with pytest.raises(NotImplementedError):
         extension.create_hook_include_file(None, None, None, None)
+    with pytest.raises(NotImplementedError):
+        extension.create_hook_populate_environment(None, None, None, None, None)
 
     coroutine = extension.generate_command_environment(None, None, None)
     with pytest.raises(NotImplementedError):

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -48,7 +48,8 @@ def test_extension_interface():
     with pytest.raises(NotImplementedError):
         extension.create_hook_include_file(None, None, None, None)
     with pytest.raises(NotImplementedError):
-        extension.create_hook_populate_environment(None, None, None, None, None)
+        extension.create_hook_populate_environment(
+            None, None, None, None, None)
 
     coroutine = extension.generate_command_environment(None, None, None)
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
This is a follow-up pull request to https://github.com/colcon/colcon-ros/pull/93.

I am proposing to extend shell extension point and add `create_hook_populate_environment` to copy the environment variable from one to another at run-time. And in this case, `colcon_ros/task/catkin/build.py` can ask the shell extension to copy the environment variable from `COLCON_CURRENT_PREFIX` to `CATKIN_ENV_HOOK_WORKSPACE` and let the shell extension decide how to implement it.