### PR TITLE
invoke pytest directly instead of through the setup.py file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 install:
   - pip install -U setuptools
   # install_requires
-  - pip install -U distlib EmPy pytest-rerunfailures pytest pytest-cov pytest-repeat pytest-runner
+  - pip install -U distlib EmPy pytest-rerunfailures pytest pytest-cov pytest-repeat
   # additional tests_require
   - pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pylint scspell3k
   # for uploading the coverage information to codecov

--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -16,6 +16,6 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 +	# would result in a runtime error by pkg_resources
 +	# pytest-repeat
 +	# pytest-rerunfailures
- 	pytest-runner
  	setuptools>=30.3.0
  packages = find:
+ tests_require = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
   pytest-cov
   pytest-repeat
   pytest-rerunfailures
-  pytest-runner
   setuptools>=30.3.0
 packages = find:
 tests_require =

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-core]
 No-Python2:
-Depends3: python3-distlib, python3-empy, python3-pytest, python3-pytest-cov, python3-pytest-runner, python3-setuptools
+Depends3: python3-distlib, python3-empy, python3-pytest, python3-pytest-cov, python3-setuptools
 Suite: xenial bionic focal stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
As of `setuptools` 41.5.0 invoking tests through the `setup.py` file is deprecated (see pypa/setuptools#1878):

> WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.

This PR only changes the `pytest` based testing extension.