### PR TITLE
fix symlink logic to not delete files in src

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -225,9 +225,9 @@ class PythonBuildTask(TaskExtensionPoint):
             if os.path.islink(dst):
                 if not os.path.exists(dst) or not os.path.samefile(src, dst):
                     os.unlink(dst)
-            elif os.path.isfile(dst):
+            elif os.path.isfile(dst) and not os.path.samefile(src, dst):
                 os.remove(dst)
-            elif os.path.isdir(dst):
+            elif os.path.isdir(dst) and not os.path.samefile(src, dst):
                 shutil.rmtree(dst)
             if not os.path.exists(dst):
                 os.symlink(src, dst)


### PR DESCRIPTION
Since a parent directory of `dst` might be symlinked to the source directory the `islink` check in the `if` isn't sufficient. The other cases still need to make sure that `dst` is not actually the same file as `src` before deleting it.

Fixes #300.