### PR TITLE
improve performance deepcopying DependencyDescriptors

### DIFF
--- a/colcon_core/dependency_descriptor.py
+++ b/colcon_core/dependency_descriptor.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import copy
+
 
 class DependencyDescriptor(str):
     """
@@ -34,3 +36,11 @@ class DependencyDescriptor(str):
         :rtype: str
         """
         return str(self)
+
+    def __deepcopy__(self, memodict):  # noqa: D105
+        # surprisingly this is significantly faster than the default
+        if not self.metadata:
+            # explicitly skipping the deep copy of an empty dict is also faster
+            return DependencyDescriptor(self.name)
+        return DependencyDescriptor(
+            self.name, metadata=copy.deepcopy(self.metadata))

--- a/colcon_core/dependency_descriptor.py
+++ b/colcon_core/dependency_descriptor.py
@@ -37,10 +37,10 @@ class DependencyDescriptor(str):
         """
         return str(self)
 
-    def __deepcopy__(self, memodict):  # noqa: D105
+    def __deepcopy__(self, memo=None):  # noqa: D105
         # surprisingly this is significantly faster than the default
         if not self.metadata:
             # explicitly skipping the deep copy of an empty dict is also faster
             return DependencyDescriptor(self.name)
         return DependencyDescriptor(
-            self.name, metadata=copy.deepcopy(self.metadata))
+            self.name, metadata=copy.deepcopy(self.metadata, memo=memo))


### PR DESCRIPTION
On a large workspace with ~300 pkgs this patch reduces the time for `colcon list` from ~1.0s to ~0.9s.

Profiling the `get_recursive_dependencies()` function shows that from ~370ms before ~310ms where spent in `deepcopy()`. With this change the `deepcopy()` part is reduced to 110ms.