### PR TITLE
Fix crash in has_test_dependency

### DIFF
--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -210,8 +210,8 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    tests_require = setup_py_data.get('tests_require', [])
-    for d in tests_require:
+    tests_require = setup_py_data.get('tests_require')
+    for d in tests_require or []:
         # the name might be followed by a version
         # separated by any of the following: ' ', <, >, <=, >=, ==, !=
         parts = re.split(r' |<|=|>|!', d)


### PR DESCRIPTION
If `setup_py_data['tests_require'] is None`, don't crash
