### PR TITLE
Generate xunit files valid for the junit10.xsd

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -147,8 +147,8 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         # and doesn't generate a result file at all
         junit_xml_path.parent.mkdir(parents=True, exist_ok=True)
         junit_xml_path.write_text("""<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="{context.pkg.name}" tests="1" failures="1" time="0" errors="0" skip="0">
-  <testcase classname="{context.pkg.name}" name="pytest.missing_result" status="run" time="0">
+<testsuite name="{context.pkg.name}" tests="1" failures="0" time="0" errors="1" skipped="0">
+  <testcase classname="{context.pkg.name}" name="pytest.missing_result" time="0">
     <failure message="The test invocation failed without generating a result file."/>
   </testcase>
 </testsuite>


### PR DESCRIPTION
Similar to https://github.com/ament/ament_lint/pull/220

I've change the `skip` attribute by "skipped", remove the non permitted `status` attribute and following the same logic exposed in [this comment](https://github.com/ament/ament_lint/pull/220#issuecomment-597765930) I changed `failures` by `errors`.