### PR TITLE
WIP: expand path arguments

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -52,7 +52,8 @@ if warnings_filters:
 from colcon_core.argument_parser import decorate_argument_parser  # noqa: E402 E501 I100 I202
 from colcon_core.argument_parser import SuppressUsageOutput  # noqa: E402
 from colcon_core.entry_point import load_entry_points  # noqa: E402
-from colcon_core.location import create_log_path  # noqa: E402
+from colcon_core.location import create_log_path, \
+    optional_expanded_path  # noqa: E402
 from colcon_core.location import get_log_path  # noqa: E402
 from colcon_core.location import set_default_config_path  # noqa: E402
 from colcon_core.location import set_default_log_path  # noqa: E402
@@ -282,6 +283,7 @@ def add_log_level_argument(parser):
     """
     parser.add_argument(
         '--log-base',
+        type=optional_expanded_path,
         help='The base path for all log directories (default: ./log, to '
              'disable: {os.devnull})'.format_map(globals()))
     parser.add_argument(

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -13,6 +13,7 @@ from colcon_core.executor import add_executor_arguments
 from colcon_core.executor import execute_jobs
 from colcon_core.executor import Job
 from colcon_core.executor import OnError
+from colcon_core.location import expanded_path, optional_expanded_path
 from colcon_core.package_identification.ignore import IGNORE_MARKER
 from colcon_core.package_selection import add_arguments \
     as add_packages_arguments
@@ -44,17 +45,14 @@ class BuildPackageArguments:
         super().__init__()
         self.path = os.path.abspath(
             os.path.join(os.getcwd(), str(pkg.path)))
-        self.build_base = os.path.abspath(os.path.join(
-            os.getcwd(), args.build_base, pkg.name))
-        self.install_base = os.path.abspath(os.path.join(
-            os.getcwd(), args.install_base))
+        self.build_base = os.path.join(args.build_base, pkg.name)
+        self.install_base = args.install_base
         self.merge_install = args.merge_install
         if not args.merge_install:
             self.install_base = os.path.join(
                 self.install_base, pkg.name)
         self.symlink_install = args.symlink_install
-        self.test_result_base = os.path.abspath(os.path.join(
-            os.getcwd(), args.test_result_base, pkg.name)) \
+        self.test_result_base = os.path.join(args.test_result_base, pkg.name) \
             if args.test_result_base else None
 
         # set additional arguments
@@ -81,10 +79,12 @@ class BuildVerb(VerbExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--build-base',
+            type=expanded_path,
             default='build',
             help='The base path for all build directories (default: build)')
         parser.add_argument(
             '--install-base',
+            type=expanded_path,
             default='install',
             help='The base path for all install prefixes (default: install)')
         parser.add_argument(
@@ -97,6 +97,7 @@ class BuildVerb(VerbExtensionPoint):
             help='Use symlinks instead of copying files where possible')
         parser.add_argument(
             '--test-result-base',
+            type=optional_expanded_path,
             help='The base path for all test results (default: --build-base)')
         parser.add_argument(
             '--continue-on-error',


### PR DESCRIPTION
Add environment variable and user path handling to path arguments.
This is motivated by wanting to do this in my colcon.yaml file instead of coding absolute paths:
`install-base: $WS_ROOT/install`

or fancier:
`log-base: ~/$ROS_DISTRO/logs`

https://gist.github.com/rotu/62cccb11b25398e9d1aa45021376d546

@dirk-thomas Initial thoughts?