### PR TITLE
print python coverage results to console

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -92,6 +92,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                     '--cov-report=xml:' + str(PurePosixPath(
                         *(Path(context.args.build_base).parts)) /
                         'coverage.xml'),
+                    '--cov-report=term',
                 ]
                 # use --cov-branch option only when available
                 # https://github.com/pytest-dev/pytest-cov/blob/v2.5.0/CHANGELOG.rst

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -86,13 +86,13 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                 args += [
                     '--cov=' + str(PurePosixPath(
                         *(Path(context.args.path).parts))),
+                    '--cov-report=term',
                     '--cov-report=html:' + str(PurePosixPath(
                         *(Path(context.args.build_base).parts)) /
                         'coverage.html'),
                     '--cov-report=xml:' + str(PurePosixPath(
                         *(Path(context.args.build_base).parts)) /
                         'coverage.xml'),
-                    '--cov-report=term',
                 ]
                 # use --cov-branch option only when available
                 # https://github.com/pytest-dev/pytest-cov/blob/v2.5.0/CHANGELOG.rst


### PR DESCRIPTION
Related to https://github.com/colcon/colcon-mixin-repository/pull/21

no print to stderr
```
root@434b2f50580b:~/ws# colcon test --packages-select sros2 --pytest-with-coverage --pytest-args --cov-report=term
Starting >>> sros2   
Finished <<< sros2 [2.84s]          

Summary: 1 package finished [3.04s]

```

Example output in stdout:

```
----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                               Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------
setup.py                              13     13      4      0     0%
sros2/__init__.py                      9      2      4      1    62%
sros2/api/__init__.py                271     58     60      8    73%
sros2/command/__init__.py              0      0      0      0   100%
sros2/command/security.py             12      2      2      1    79%
sros2/policy/__init__.py              39      5      2      1    85%
sros2/verb/__init__.py                12      2      0      0    83%
sros2/verb/create_key.py              15      3      0      0    80%
sros2/verb/create_keystore.py         14      3      0      0    79%
sros2/verb/create_permission.py       25     25      0      0     0%
sros2/verb/distribute_key.py          16     16      0      0     0%
sros2/verb/generate_artifacts.py      25     25      0      0     0%
sros2/verb/generate_policy.py         86     11     28      7    82%
sros2/verb/list_keys.py               19      3      2      1    81%
--------------------------------------------------------------------
TOTAL                                556    168    102     19    67%
Coverage HTML written to dir /root/ws/build/sros2/coverage.html
Coverage XML written to file /root/ws/build/sros2/coverage.xml

```

It can be less verbose by not printing all files 100% covered. It can also be made more verbose by printing line numbers of lines not covered