### PR TITLE
Revert "print python coverage results to console"

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -86,7 +86,6 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                 args += [
                     '--cov=' + str(PurePosixPath(
                         *(Path(context.args.path).parts))),
-                    '--cov-report=term',
                     '--cov-report=html:' + str(PurePosixPath(
                         *(Path(context.args.build_base).parts)) /
                         'coverage.html'),


### PR DESCRIPTION
Reverts colcon/colcon-core#331 - see https://github.com/colcon/colcon-core/pull/331#issuecomment-606892768.