### PR TITLE
deprecate colcon_core.task.check_output()

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -14,7 +14,7 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import create_environment_hook
 from colcon_core.shell import get_command_environment
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_core.task.python import get_data_files_mapping
 from colcon_core.task.python import get_setup_data
@@ -73,7 +73,7 @@ class PythonBuildTask(TaskExtensionPoint):
                 '--single-version-externally-managed',
             ]
             self._append_install_layout(args, cmd)
-            completed = await check_call(
+            completed = await run(
                 self.context, cmd, cwd=args.path, env=env)
             if completed.returncode:
                 return completed.returncode
@@ -97,7 +97,7 @@ class PythonBuildTask(TaskExtensionPoint):
             if setup_py_data.get('data_files'):
                 cmd += ['install_data', '--install-dir', args.install_base]
             self._append_install_layout(args, cmd)
-            completed = await check_call(
+            completed = await run(
                 self.context, cmd, cwd=args.build_base, env=env)
             if completed.returncode:
                 return completed.returncode
@@ -132,7 +132,7 @@ class PythonBuildTask(TaskExtensionPoint):
                 '--uninstall', '--editable',
                 '--build-directory', os.path.join(args.build_base, 'build')
             ]
-            completed = await check_call(
+            completed = await run(
                 self.context, cmd, cwd=args.build_base, env=env)
             return completed.returncode
 

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -9,7 +9,7 @@ import sys
 from colcon_core.event.test import TestFailure
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task.python.test import has_test_dependency
 from colcon_core.task.python.test import PythonTestingStepExtensionPoint
 from colcon_core.verb.test import logger
@@ -155,7 +155,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
 </testsuite>
 """.format_map(locals()))  # noqa: E501
 
-        completed = await check_call(
+        completed = await run(
             context, cmd, cwd=context.args.path, env=env)
 
         # use local import to avoid a dependency on pytest

--- a/colcon_core/task/python/test/setuppy_test.py
+++ b/colcon_core/task/python/test/setuppy_test.py
@@ -4,7 +4,7 @@
 from sys import executable
 
 from colcon_core.plugin_system import satisfies_version
-from colcon_core.task import check_call
+from colcon_core.task import run
 from colcon_core.task.python.test import PythonTestingStepExtensionPoint
 from colcon_core.verb.test import logger
 
@@ -45,6 +45,6 @@ class SetuppyPythonTestingStep(PythonTestingStepExtensionPoint):
         cmd = [executable, '-m', 'unittest', '-v']
         if context.args.unittest_args is not None:
             cmd += context.args.unittest_args
-        completed = await check_call(
+        completed = await run(
             context, cmd, cwd=context.args.path, env=env)
         return completed.returncode

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -12,11 +12,11 @@ from colcon_core.event.output import StderrLine
 from colcon_core.event.output import StdoutLine
 from colcon_core.plugin_system import instantiate_extensions
 from colcon_core.task import add_task_arguments
-from colcon_core.task import check_call
 from colcon_core.task import create_file
 from colcon_core.task import get_task_extension
 from colcon_core.task import get_task_extensions
 from colcon_core.task import install
+from colcon_core.task import run
 from colcon_core.task import TaskContext
 from colcon_core.task import TaskExtensionPoint
 from mock import Mock
@@ -78,7 +78,7 @@ def test_extension_interface():
 @pytest.mark.skip(
     reason='Results in stderr output due to a UnicodeDecodeError for the '
            'generated coverage files')
-def test_check_call():
+def test_run():
     context = Mock()
     events = []
 
@@ -90,7 +90,7 @@ def test_check_call():
     cmd = [
         sys.executable, '-c',
         "import sys; print('hello'); print('world', file=sys.stderr)"]
-    coroutine = check_call(context, cmd)
+    coroutine = run(context, cmd)
     completed_process = run_until_complete(coroutine)
     assert completed_process.returncode == 0
     assert len(events) == 3


### PR DESCRIPTION
Resolves #237.