### PR TITLE
make import locally to avoid failures when not even being used

### DIFF
--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -8,20 +8,6 @@ from colcon_core.package_identification \
 from colcon_core.plugin_system import satisfies_version
 from distlib.util import parse_requirement
 from distlib.version import NormalizedVersion
-try:
-    from setuptools.config import read_configuration
-except ImportError as e:
-    from pkg_resources import get_distribution
-    from pkg_resources import parse_version
-    setuptools_version = get_distribution('setuptools').version
-    minimum_version = '30.3.0'
-    if parse_version(setuptools_version) < parse_version(minimum_version):
-        e.msg += ', ' \
-            "'setuptools' needs to be at least version {minimum_version}, if" \
-            ' a newer version is not available from the package manager use ' \
-            "'pip3 install -U setuptools' to update to the latest version" \
-            .format_map(locals())
-    raise
 
 
 class PythonPackageIdentification(PackageIdentificationExtensionPoint):
@@ -113,6 +99,21 @@ def get_configuration(setup_cfg):
     :returns: The configuration data
     :rtype: dict
     """
+    try:
+        # import locally to allow other functions in this module to be usable
+        from setuptools.config import read_configuration
+    except ImportError as e:
+        from pkg_resources import get_distribution
+        from pkg_resources import parse_version
+        setuptools_version = get_distribution('setuptools').version
+        minimum_version = '30.3.0'
+        if parse_version(setuptools_version) < parse_version(minimum_version):
+            e.msg += ', ' \
+                "'setuptools' needs to be at least version " \
+                '{minimum_version}, if a newer version is not available ' \
+                "from the package manager use 'pip3 install -U setuptools' " \
+                'to update to the latest version'.format_map(locals())
+        raise
     return read_configuration(str(setup_cfg))
 
 


### PR DESCRIPTION
E.g. https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_kinetic-xenial-amd64/110/ fails with:

```
ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.package_identification.ros': No module named 'setuptools.config', 'setuptools' needs to be at least version 30.3.0, if a newer version is not available from the package manager use 'pip3 install -U setuptools' to update to the latest version
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/colcon_core/entry_point.py", line 101, in load_entry_points
    extension_type = load_entry_point(entry_point)
  File "/usr/lib/python3/dist-packages/colcon_core/entry_point.py", line 143, in load_entry_point
    return entry_point.load()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python3/dist-packages/colcon_ros/package_identification/ros.py", line 12, in <module>
    from colcon_core.package_identification.python import get_configuration
  File "/usr/lib/python3/dist-packages/colcon_core/package_identification/python.py", line 12, in <module>
    from setuptools.config import read_configuration
ImportError: No module named 'setuptools.config', 'setuptools' needs to be at least version 30.3.0, if a newer version is not available from the package manager use 'pip3 install -U setuptools' to update to the latest version
```

even though no packages in the workspace are actually Python packages.

This patch moves the import into local scope to only happen when actually being used.