### PR TITLE
use pytest hook to redirect pytest warnings to stderr

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -177,6 +177,11 @@ def _main(*, command_name, argv):
             None, None)
         handler.handle(log_record)
 
+    # set an environment variable named after the command (if not already set)
+    # which allows subprocesses to identify they are invoked by this command
+    if command_name.upper() not in os.environ:
+        os.environ[command_name.upper()] = '1'
+
     # invoke verb
     return verb_main(context, colcon_logger)
 

--- a/colcon_core/pytest/hooks.py
+++ b/colcon_core/pytest/hooks.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import os
+import sys
+import types
+
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Redirect the summary warnings to stderr when run within colcon."""
+    summary_warnings = terminalreporter.summary_warnings
+
+    def redirect_to_stderr(self):
+        nonlocal summary_warnings
+        tw = self._tw
+        import _pytest.config
+        self._tw = _pytest.config.create_terminal_writer(
+            self.config, sys.stderr)
+        summary_warnings()
+        self._tw = tw
+
+    if 'COLCON' in os.environ:
+        terminalreporter.summary_warnings = types.MethodType(
+            redirect_to_stderr, terminalreporter)
+    yield

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,6 +126,8 @@ colcon_core.verb =
     test = colcon_core.verb.test:TestVerb
 console_scripts =
     colcon = colcon_core.command:main
+pytest11 =
+    colcon_core_warnings_stderr = colcon_core.pytest.hooks
 
 [options.package_data]
 colcon_core.shell.template = *.em


### PR DESCRIPTION
To avoid using the same redirect in non-colcon pytest invocations the custom hook is only changing the behavior when the environment variable `COLCON` is set.