### PR TITLE
Allow ignore_marker to be a dangling symlink

### DIFF
--- a/colcon_core/package_identification/ignore.py
+++ b/colcon_core/package_identification/ignore.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import os.path
 from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
@@ -23,5 +24,5 @@ class IgnorePackageIdentification(PackageIdentificationExtensionPoint):
 
     def identify(self, desc):  # noqa: D102
         colcon_ignore = desc.path / IGNORE_MARKER
-        if colcon_ignore.lexists():
+        if os.path.lexists(str(colcon_ignore)):
             raise IgnoreLocationException()

--- a/colcon_core/package_identification/ignore.py
+++ b/colcon_core/package_identification/ignore.py
@@ -23,5 +23,5 @@ class IgnorePackageIdentification(PackageIdentificationExtensionPoint):
 
     def identify(self, desc):  # noqa: D102
         colcon_ignore = desc.path / IGNORE_MARKER
-        if colcon_ignore.exists():
+        if colcon_ignore.lexists():
             raise IgnoreLocationException()

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -159,7 +159,7 @@ class BuildVerb(VerbExtensionPoint):
         if not path.exists():
             path.mkdir(parents=True, exist_ok=True)
         ignore_marker = path / IGNORE_MARKER
-        if not ignore_marker.exists():
+        if not ignore_marker.lexists():
             with ignore_marker.open('w'):
                 pass
 

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 import os
+import os.path
 from pathlib import Path
 import traceback
 
@@ -159,7 +160,7 @@ class BuildVerb(VerbExtensionPoint):
         if not path.exists():
             path.mkdir(parents=True, exist_ok=True)
         ignore_marker = path / IGNORE_MARKER
-        if not ignore_marker.lexists():
+        if not os.path.lexists(str(ignore_marker)):
             with ignore_marker.open('w'):
                 pass
 


### PR DESCRIPTION
As per https://github.com/ros-infrastructure/rep/pull/256
