### PR TITLE
make CodeCov results informational, not affecting status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      threshold:
+        threshold: 0%


### PR DESCRIPTION
Otherwise commits are marked with :x: when coverage thresholds aren't met (which the package currently doesn't require / enforce) and it is difficult to see if a commit has actual test failures.