### PR TITLE
suppress stacktrace for RuntimeError raised by event handler

### DIFF
--- a/colcon_core/event_reactor.py
+++ b/colcon_core/event_reactor.py
@@ -79,11 +79,12 @@ class EventReactor:
                 assert retval is None, 'event handler should return None'
             except Exception as e:  # noqa: F841
                 # catch exceptions raised in event handler extension
-                exc = traceback.format_exc()
-                logger.error(
-                    'Exception in event handler extension '
-                    "'{observer.EVENT_HANDLER_NAME}': {e}\n{exc}"
-                    .format_map(locals()))
+                msg = 'Exception in event handler extension ' \
+                    "'{observer.EVENT_HANDLER_NAME}': {e}" \
+                    .format_map(locals())
+                if not isinstance(e, RuntimeError):
+                    msg += '\n' + traceback.format_exc()
+                logger.error(msg)
                 # skip failing extension, continue with next one
 
     def flush(self):

--- a/test/test_event_reactor.py
+++ b/test/test_event_reactor.py
@@ -39,8 +39,10 @@ class Extension3(CustomExtension):
 
     def __call__(self, event):
         super().__call__(event)
-        if event[0] in ('first', 'third'):
-            raise RuntimeError('custom exception')
+        if event[0] == 'first':
+            raise ValueError("ValueError for '%s'" % event[0])
+        if event[0] == 'third':
+            raise RuntimeError("RuntimeError for '%s'" % event[0])
 
 
 def test_create_event_reactor():
@@ -92,11 +94,11 @@ def test_create_event_reactor():
         assert len(error.call_args_list[0][0]) == 1
         assert error.call_args_list[0][0][0].startswith(
             "Exception in event handler extension 'extension3': "
-            'custom exception\n')
+            "ValueError for 'first'\n")
         assert len(error.call_args_list[1][0]) == 1
         assert error.call_args_list[1][0][0].startswith(
             "Exception in event handler extension 'extension3': "
-            'custom exception\n')
+            "RuntimeError for 'third'")
 
         # wait for another timer event to be generated
         time.sleep(1.5 * event_reactor.TIMER_INTERVAL)


### PR DESCRIPTION
This allows event handlers to reduce the clutter when known problems occur.