### PR TITLE
[windows] fix _colcon_python_executable fallback code path.

### DIFF
--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -52,6 +52,7 @@ goto:eof
 :: Run the commands in topological order
 :: first argument: the base path to look for packages
 :_colcon_run_ordered_commands
+  setlocal enabledelayedexpansion
   :: check environment variable for custom Python executable
   if "%COLCON_PYTHON_EXECUTABLE%" NEQ "" (
     if not exist "%COLCON_PYTHON_EXECUTABLE%" (
@@ -63,7 +64,7 @@ goto:eof
     :: use the Python executable known at configure time
     set "_colcon_python_executable=@(python_executable)"
     :: if it doesn't exist try a fall back
-    if not exist "%_colcon_python_executable%" (
+    if not exist "!_colcon_python_executable!" (
       python --version > NUL 2> NUL
       if errorlevel 1 (
         echo error: unable to find python executable
@@ -71,6 +72,10 @@ goto:eof
       )
       set "_colcon_python_executable=python"
     )
+  )
+
+  endlocal & (
+    set "_colcon_python_executable=%_colcon_python_executable%"
   )
 
   for /f "delims=" %%c in ('""%_colcon_python_executable%" "%~1_local_setup_util_bat.py" bat@


### PR DESCRIPTION
In the `local_setup.bat`, it first attempt to use the Python binary decided at compile time. If it doesn't exist, it will then test the first one visible from `%PATH%`. In the cases of no Python in the `%PATH%`, it will error on with `error: unable to find python executable`.

However, in my setting, I don't have any Python binary in `%PATH%`, but I do have the Python binary under `@(python_executable)` which decided at the compile time. By the logic, it should firstly find that one, but it error out with `error: unable to find python executable` instead.

After digging, it turned out that when accessing the variable is set within a FOR loop or IF block, one have to turn on `setlocal enabledelayedexpansion` and use `!_colcon_python_executable!` to access the values. This pull request is to correct this usage.