### PR TITLE
avoid warning introduced in setuptools 49.2.0

### DIFF
--- a/colcon_core/environment/pythonpath.py
+++ b/colcon_core/environment/pythonpath.py
@@ -1,6 +1,11 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from contextlib import suppress
+with suppress(ImportError):
+    # needed before importing distutils
+    # to avoid warning introduced in setuptools 49.2.0
+    import setuptools  # noqa: F401
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -2,6 +2,10 @@
 # Licensed under the Apache License, Version 2.0
 
 from contextlib import suppress
+with suppress(ImportError):
+    # needed before importing distutils
+    # to avoid warning introduced in setuptools 49.2.0
+    import setuptools  # noqa: F401
 from distutils.sysconfig import get_python_lib
 import os
 from pathlib import Path


### PR DESCRIPTION
Fixes  colcon/colcon-python-setup-py#38.

See https://setuptools.readthedocs.io/en/latest/history.html#v49-2-0