### PR TITLE
catch KeyboardInterrupt in another case to avoid stacktrace

### DIFF
--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -186,7 +186,7 @@ async def _async_check_call(
                     callbacks[i] = asyncio.ensure_future(callback)
         try:
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, KeyboardInterrupt):
             # finish the communication with the subprocess
             done, _ = await asyncio.wait(callbacks, return_when=ALL_COMPLETED)
             raise


### PR DESCRIPTION
Depending on the timing a `KeyboardInterrupt` can be raise in this location which leads to a stacktrace and incomplete termination.