### PR TITLE
Bugfix missing explicit key updates in update_descriptor

### DIFF
--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -135,6 +135,15 @@ def update_descriptor(
     :param additional_argument_names: A dict of option names to destination
       names or a list of argument names
     """
+    # explicit key updates
+    try:
+        desc.name = data['name']
+    except KeyError:
+        pass
+    try:
+        desc.type = data['type']
+    except KeyError:
+        pass
     dep_types = ('build', 'run', 'test')
     # transfer generic dependencies to each specific type
     if 'dependencies' in data:

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -7,6 +7,7 @@ basepath
 blocklist
 capsys
 catched
+cmake
 colcon
 contextlib
 coroutine

--- a/test/test_package_augmentation.py
+++ b/test/test_package_augmentation.py
@@ -149,6 +149,14 @@ def test_update_descriptor():
     assert 'some' in desc.metadata
     assert desc.metadata['some'] == 'value'
 
+    data = {
+        'name': 'foo',
+        'type': 'cmake',
+    }
+    update_descriptor(desc, data)
+    assert desc.name == 'foo'
+    assert desc.type == 'cmake'
+
 
 def test_update_metadata():
     desc = PackageDescriptor('/some/path')


### PR DESCRIPTION
The implementation for that described in the method comment was missing, leading to this issue for colcon_meta &rarr; https://github.com/colcon/colcon-metadata/issues/23.