### PR TITLE
improve error message when em.* can't be imported, suggest collision between empy and em

### DIFF
--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -5,8 +5,18 @@ from io import StringIO
 import os
 
 from colcon_core.logging import colcon_logger
-from em import Interpreter
-from em import OVERRIDE_OPT
+try:
+    from em import Interpreter
+    from em import OVERRIDE_OPT
+except ImportError as e:
+    try:
+        import em  # noqa: F401
+    except ImportError:
+        e.msg += " The Python package 'empy' must be installed"
+        raise e from None
+    e.msg += " The Python package 'empy' must be installed and 'em' must " \
+        'not be installed since both packages share the same namespace'
+    raise e from None
 
 logger = colcon_logger.getChild(__name__)
 


### PR DESCRIPTION
The Python packages `empy` (needed by `colcon` for templates) and `em` have the same namespace. If the latter is installed the former will not be usable, see e.g. https://answers.ros.org/question/359578/colcon-build-symlink-install-cant-find-__main__-module-ld-cannot-find-lpthreads/ The import could also fail if `empy` is just not installed.

This patch aims to provide an improved error message for the failing import to distinguish these cases.