### PR TITLE
add setuptools to setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
   pytest-cov
   pytest-repeat
   pytest-rerunfailures
-  setuptools>=46.4.0
+  setuptools>=30.3.0
 packages = find:
 tests_require =
   flake8>=3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ keywords = colcon
 
 [options]
 python_requires = >=3.5
+setup_requires =
+  setuptools>=46.4.0
 install_requires =
   coloredlogs; sys_platform == 'win32'
   distlib
@@ -36,7 +38,7 @@ install_requires =
   pytest-cov
   pytest-repeat
   pytest-rerunfailures
-  setuptools>=30.3.0
+  setuptools>=46.4.0
 packages = find:
 tests_require =
   flake8>=3.6.0


### PR DESCRIPTION
Due to issues discussed in #374, colcon-core setup requires setuptools 46.4.0 to install correctly.