### PR TITLE
Pass --egg-base as relative.

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -67,9 +67,10 @@ class PythonBuildTask(TaskExtensionPoint):
 
             # invoke `setup.py install` step with lots of arguments
             # to avoid placing any files in the source space
+            rel_build_base = os.path.relpath(args.build_base, args.path)
             cmd = [
                 executable, 'setup.py',
-                'egg_info', '--egg-base', args.build_base,
+                'egg_info', '--egg-base', rel_build_base,
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),
                 'install', '--prefix', args.install_base,

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -67,10 +67,10 @@ class PythonBuildTask(TaskExtensionPoint):
 
             # invoke `setup.py install` step with lots of arguments
             # to avoid placing any files in the source space
-            rel_build_base = os.path.relpath(args.build_base, args.path)
             cmd = [
                 executable, 'setup.py',
-                'egg_info', '--egg-base', rel_build_base,
+                'egg_info', '--egg-base', os.path.relpath(
+                    args.build_base, args.path),
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),
                 'install', '--prefix', args.install_base,


### PR DESCRIPTION
It seems setuptools doesn't like `--egg-base` to be an absolute path. Example with setuptools 45.2.0 (Ubuntu Focal):

```
--- stderr: canopen
error: Error: setup script specifies an absolute path:

    /home/administrator/ws/build/canopen/canopen.egg-info/PKG-INFO

setup() arguments must *always* be /-separated paths relative to the
setup.py directory, *never* absolute paths.

---
Failed   <<< canopen [1.41s, exited with code 1]
```

The error goes away if I compute the `--egg-base` argument as a path relative to the cwd, as in this PR.