### PR TITLE
fix warnings in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 install:
   # avoid warnings which could also be suppressed with --no-warn-script-location
   - set "PATH=%PYTHON%\Scripts;%PATH%"
-  - "%PYTHON%\\python.exe -m pip install -U setuptools"
+  - "%PYTHON%\\python.exe -m pip install -U pip setuptools"
   # install_requires
   - "%PYTHON%\\python.exe -m pip install -U coloredlogs distlib EmPy"
   # tests_require, additionally mock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ environment:
   matrix:
     - PYTHON: "C:\\Python36-x64"
 install:
+  # avoid warnings which could also be suppressed with --no-warn-script-location
+  - set "PATH=%PYTHON%\Scripts;%PATH%"
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   # install_requires
   - "%PYTHON%\\python.exe -m pip install -U coloredlogs distlib EmPy"

--- a/colcon_core/__init__.py
+++ b/colcon_core/__init__.py
@@ -1,6 +1,4 @@
 # Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import sys
-
 __version__ = '0.6.1'

--- a/colcon_core/__init__.py
+++ b/colcon_core/__init__.py
@@ -1,4 +1,6 @@
 # Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import sys
+
 __version__ = '0.6.1'

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -10,8 +10,8 @@ from flake8.api.legacy import get_style_guide
 from pydocstyle.utils import log
 
 
-# avoid debug and info messages from flake8 internals
-LOG.setLevel(logging.WARNING)
+# avoid debug / info / warning messages from flake8 internals
+LOG.setLevel(logging.ERROR)
 
 
 def test_flake8():


### PR DESCRIPTION
**AppVeyor:**

* The first commit fixes #401.
* The second commit avoids another warning on AppVeyor about the `pip` version being outdated.

**Travis CI:**

* The fourth commit fixes #400 which only occurs if there are flake8 error (so it doesn't appear in passing CI builds).
   * The third commit adds a linter error to check the fourth commit. The fifth commit reverts that linter error again.