### PR TITLE
fix regression when package dir is symlinked

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -75,9 +75,11 @@ class PythonBuildTask(TaskExtensionPoint):
             if 'egg_info' in available_commands:
                 # `setup.py egg_info` requires the --egg-base to exist
                 os.makedirs(args.build_base, exist_ok=True)
+                # symlinks are resolved for args.path when used as cwd below
                 cmd += [
                     'egg_info', '--egg-base',
-                    os.path.relpath(args.build_base, args.path)]
+                    os.path.relpath(
+                        args.build_base, os.path.realpath(args.path))]
             cmd += [
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),


### PR DESCRIPTION
Fix regression introduced in #387 when the package source dir is a symlink.

@mikepurvis FYI.