### PR TITLE
Assert that the Python build actually succeeds

### DIFF
--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -84,7 +84,8 @@ def test_build_package():
             src_base = Path(python_build_task.context.args.path)
 
             source_files_before = set(src_base.rglob('*'))
-            assert not event_loop.run_until_complete(python_build_task.build())
+            rc = event_loop.run_until_complete(python_build_task.build())
+            assert not rc
             source_files_after = set(src_base.rglob('*'))
             assert source_files_before == source_files_after
 

--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -84,7 +84,7 @@ def test_build_package():
             src_base = Path(python_build_task.context.args.path)
 
             source_files_before = set(src_base.rglob('*'))
-            event_loop.run_until_complete(python_build_task.build())
+            assert not event_loop.run_until_complete(python_build_task.build())
             source_files_after = set(src_base.rglob('*'))
             assert source_files_before == source_files_after
 


### PR DESCRIPTION
If the build does fail, it would be good to have an earlier indication of where things went awry.

This function appears to return `None` on success, or an error code value on failure.