### PR TITLE
Suppress blind exception flake8 errors

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -34,7 +34,7 @@ if warnings_filters:
         action, message, category, module, line = fields
         try:
             category = warnings._getcategory(category)
-        except Exception:
+        except Exception:  # noqa: B902
             print(
                 "The category field '{category}' must be a valid warnings "
                 'class name'.format_map(locals()), file=sys.stderr)

--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -91,7 +91,7 @@ class Job:
             rc = await self.task(*args, **kwargs)
         except CancelledError:
             rc = SIGINT_RESULT
-        except Exception:
+        except Exception:  # noqa: B902
             rc = 1
             self.put_event_into_queue(
                 StderrLine(traceback.format_exc().encode()))


### PR DESCRIPTION
I think it is acceptable to catch a generic Exception in both
places where the error is being reported.

In the command.py, we could use the exception type
`warnings._OptionError`, but I don't think it's safe to rely this
private exception type as it might not remain stable in future.
It would be better to not call the private function altogether,
but I'm not sure how best to avoid it.

In executor/\_\_init\_\_.py, we are propagating the exception in the
except block. In this case, I consider the linter is reporting a false-positive,
as it is unable to handle this situation.

---

This should fix recent CI failures, [for example](https://travis-ci.org/github/colcon/colcon-core/jobs/753488935).