### PR TITLE
Escape closing parenthesis in prefix.bat file

### DIFF
--- a/colcon_core/shell/template/prefix.bat.em
+++ b/colcon_core/shell/template/prefix.bat.em
@@ -78,6 +78,8 @@ goto:eof
     set "_colcon_python_executable=%_colcon_python_executable%"
   )
 
+  :: escape potential closing parenthesis which would break the for loop
+  set "_colcon_python_executable=%_colcon_python_executable:)=^)%"
   for /f "delims=" %%c in ('""%_colcon_python_executable%" "%~1_local_setup_util_bat.py" bat@
 @[if merge_install]@
  --merged-install@


### PR DESCRIPTION
An un-escaped closing parentheses will break the for loop that is using this value.

This same fix was already implemented in ament/ament_package#91.