### PR TITLE
Expand shell wildcards in --paths for all platforms

### DIFF
--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -188,9 +188,12 @@ def discover_packages(
         args, identification_extensions, discovery_extensions)
 
 
-def expand_wildcards(paths):
+def expand_dir_wildcards(paths):
     """
-    Expand wildcards explicitly.
+    Expand wildcards explicitly to match directories.
+
+    This function does not match files.
+    Also, unlike shells, it does not keep patterns that yield no matches.
 
     This is only necessary on Windows or when
     the wildcards are not expanded by the shell.
@@ -207,7 +210,7 @@ def expand_wildcards(paths):
             p for p in sorted(glob(path))
             if os.path.isdir(p)]
         logger.log(
-            5, "expand_wildcards() expanding '%s' to %s",
+            5, "expand_dir_wildcards() expanding '%s' to %s",
             path, expanded_paths)
         paths[i:i + 1] = expanded_paths
         i += len(expanded_paths)

--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0
 
 from collections import OrderedDict
+from glob import glob
+import os
 import traceback
 
 from colcon_core.logging import colcon_logger
@@ -184,6 +186,31 @@ def discover_packages(
 
     return _discover_packages(
         args, identification_extensions, discovery_extensions)
+
+
+def expand_wildcards(paths):
+    """
+    Expand wildcards explicitly.
+
+    This is only necessary on Windows or when
+    the wildcards are not expanded by the shell.
+
+    :param list paths: The paths to update in place
+    """
+    i = 0
+    while i < len(paths):
+        path = paths[i]
+        if '*' not in path:
+            i += 1
+            continue
+        expanded_paths = [
+            p for p in sorted(glob(path))
+            if os.path.isdir(p)]
+        logger.log(
+            5, "expand_wildcards() expanding '%s' to %s",
+            path, expanded_paths)
+        paths[i:i + 1] = expanded_paths
+        i += len(expanded_paths)
 
 
 def _get_extensions_with_parameters(

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -3,7 +3,6 @@
 
 from glob import glob
 import os
-import sys
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
@@ -45,9 +44,9 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
         if args.paths is None:
             return set()
 
-        # on Windows manually check for wildcards and expand them
-        if sys.platform == 'win32':
-            _expand_wildcards(args.paths)
+        # manually check for wildcards and expand them in case
+        # the values were not provided through the shell
+        _expand_wildcards(args.paths)
 
         logger.log(1, 'PathPackageDiscovery.discover(%s)', args.paths)
 

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -1,11 +1,11 @@
 # Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from glob import glob
 import os
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
+from colcon_core.package_discovery import expand_wildcards
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
@@ -46,7 +46,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
 
         # manually check for wildcards and expand them in case
         # the values were not provided through the shell
-        _expand_wildcards(args.paths)
+        expand_wildcards(args.paths)
 
         logger.log(1, 'PathPackageDiscovery.discover(%s)', args.paths)
 
@@ -67,27 +67,3 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
                 descs.add(result)
 
         return descs
-
-
-def _expand_wildcards(paths):
-    """
-    Expand wildcards explicitly.
-
-    This is only necessary on Windows.
-
-    :param list paths: The paths to update in place
-    """
-    i = 0
-    while i < len(paths):
-        path = paths[i]
-        if '*' not in path:
-            i += 1
-            continue
-        expanded_paths = [
-            p for p in sorted(glob(path))
-            if os.path.isdir(p)]
-        logger.log(
-            5, "PathPackageDiscovery.discover() expanding '%s' to %s",
-            path, expanded_paths)
-        paths[i:i + 1] = expanded_paths
-        i += len(expanded_paths)

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -5,7 +5,7 @@ import os
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
-from colcon_core.package_discovery import expand_wildcards
+from colcon_core.package_discovery import expand_dir_wildcards
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from colcon_core.package_identification import identify
@@ -46,7 +46,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
 
         # manually check for wildcards and expand them in case
         # the values were not provided through the shell
-        expand_wildcards(args.paths)
+        expand_dir_wildcards(args.paths)
 
         logger.log(1, 'PathPackageDiscovery.discover(%s)', args.paths)
 

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -10,7 +10,7 @@ from colcon_core.package_discovery import _discover_packages
 from colcon_core.package_discovery import _get_extensions_with_parameters
 from colcon_core.package_discovery import add_package_discovery_arguments
 from colcon_core.package_discovery import discover_packages
-from colcon_core.package_discovery import expand_wildcards
+from colcon_core.package_discovery import expand_dir_wildcards
 from colcon_core.package_discovery import get_package_discovery_extensions
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from mock import Mock
@@ -133,7 +133,7 @@ def test_discover_packages():
         assert expected_path in (str(d.path) for d in descs)
 
 
-def test_expand_wildcards():
+def test_expand_dir_wildcards():
     with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
         prefix_path = Path(prefix_path)
         (prefix_path / 'one').mkdir()
@@ -144,7 +144,7 @@ def test_expand_wildcards():
             '/some/path',
             str(prefix_path / '*')
         ]
-        expand_wildcards(paths)
+        expand_dir_wildcards(paths)
         assert len(paths) == 3
         assert paths[0] == '/some/path'
         assert paths[1] == str((prefix_path / 'one'))

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -2,12 +2,15 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_discovery import _discover_packages
 from colcon_core.package_discovery import _get_extensions_with_parameters
 from colcon_core.package_discovery import add_package_discovery_arguments
 from colcon_core.package_discovery import discover_packages
+from colcon_core.package_discovery import expand_wildcards
 from colcon_core.package_discovery import get_package_discovery_extensions
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
 from mock import Mock
@@ -128,6 +131,24 @@ def test_discover_packages():
         assert expected_path in (str(d.path) for d in descs)
         expected_path = '/extension3/pkg2'.replace('/', os.sep)
         assert expected_path in (str(d.path) for d in descs)
+
+
+def test_expand_wildcards():
+    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
+        prefix_path = Path(prefix_path)
+        (prefix_path / 'one').mkdir()
+        (prefix_path / 'two').mkdir()
+        (prefix_path / 'three').touch()
+
+        paths = [
+            '/some/path',
+            str(prefix_path / '*')
+        ]
+        expand_wildcards(paths)
+        assert len(paths) == 3
+        assert paths[0] == '/some/path'
+        assert paths[1] == str((prefix_path / 'one'))
+        assert paths[2] == str((prefix_path / 'two'))
 
 
 def test__get_extensions_with_parameters():

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from colcon_core.package_descriptor import PackageDescriptor
-from colcon_core.package_discovery.path import _expand_wildcards
 from colcon_core.package_discovery.path import PathPackageDiscovery
 from colcon_core.package_identification import IgnoreLocationException
 from mock import Mock
@@ -84,21 +83,3 @@ def test_discover_with_wildcards():
                 PackageDescriptor(os.path.realpath(str(path_one))),
                 PackageDescriptor(os.path.realpath(str(path_two))),
                 PackageDescriptor(os.path.realpath(str(path_three)))}
-
-
-def test__expand_wildcards():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        (prefix_path / 'one').mkdir()
-        (prefix_path / 'two').mkdir()
-        (prefix_path / 'three').touch()
-
-        paths = [
-            '/some/path',
-            str(prefix_path / '*')
-        ]
-        _expand_wildcards(paths)
-        assert len(paths) == 3
-        assert paths[0] == '/some/path'
-        assert paths[1] == str((prefix_path / 'one'))
-        assert paths[2] == str((prefix_path / 'two'))

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -63,6 +63,29 @@ def test_discover():
             PackageDescriptor(os.path.realpath('/other/path'))}
 
 
+def test_discover_with_wildcards():
+    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
+        prefix_path = Path(prefix_path)
+        path_one = prefix_path / 'one' / 'path'
+        path_two = prefix_path / 'two' / 'path'
+        path_three = prefix_path / 'three' / 'path'
+        path_one.mkdir(parents=True)
+        path_two.mkdir(parents=True)
+        path_three.mkdir(parents=True)
+
+        extension = PathPackageDiscovery()
+        args = Mock()
+        args.paths = [str(prefix_path / '*' / 'path')]
+        with patch(
+            'colcon_core.package_discovery.path.identify', side_effect=identify
+        ):
+            descs = extension.discover(args=args, identification_extensions={})
+            assert descs == {
+                PackageDescriptor(os.path.realpath(str(path_one))),
+                PackageDescriptor(os.path.realpath(str(path_two))),
+                PackageDescriptor(os.path.realpath(str(path_three)))}
+
+
 def test__expand_wildcards():
     with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
         prefix_path = Path(prefix_path)


### PR DESCRIPTION
Fixes #438

If the `--paths` value is not provided through the shell, then shell wildcards won't be expanded. This is the case when using a `defaults.yaml` file.

To cover this case, expand wildcards on all platforms, not just Windows. I renamed and made `expand_wildcards` part of the public API so that it can be used elsewhere as well.

I can't think of any downsides to doing this, and being able to use wildcards in a `defaults.yaml` file does seem like a very normal use case.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>