### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,10 @@ install_requires =
   pytest-rerunfailures
   setuptools>=30.3.0
 packages = find:
-tests_require =
+zip_safe = false
+
+[options.extras_require]
+test =
   flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
@@ -54,7 +57,6 @@ tests_require =
   pytest
   pytest-cov
   scspell3k>=2.2
-zip_safe = false
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This replaces `tests_require` with a pattern that seems to have popped
up since pypa/setuptools#931 and pypa/setuptools#1684. It allows test
dependencies to be installed by adding `[test]` to the end of the
package name.

Example installing test dependencies and running pytest:

```
python3 -m venv env3
. env3/bin/activate
cd colcon-core/
pip install -e .[test]
pytest
```

I chose `test`, but the naming is inconsistent. I've found other
examples using `tests` or `testing` as well.

I opened this because it could get rid of the duplication of test dependencies from the CI scripts in #414 (@cottsay FYI)