### PR TITLE
Extract test dependencies from options.extras_require.test

### DIFF
--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -75,19 +75,21 @@ def extract_dependencies(options):
         'tests_require': 'test',
     }
     dependencies = {}
-    _map_dependencies(mapping, options, dependencies)
+    _map_dependencies(options, mapping, dependencies)
 
     extras_mapping = {
         'test': 'test',
+        'tests': 'test',
+        'testing': 'test',
     }
     _map_dependencies(
-        extras_mapping, options.get('extras_require', {}),
+        options.get('extras_require', {}), extras_mapping,
         dependencies)
 
     return dependencies
 
 
-def _map_dependencies(mapping, options, dependencies):
+def _map_dependencies(options, mapping, dependencies):
     for option_name, dependency_type in mapping.items():
         dependencies.setdefault(dependency_type, set())
         for dep in options.get(option_name, []):

--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -75,21 +75,24 @@ def extract_dependencies(options):
         'tests_require': 'test',
     }
     dependencies = {}
-    for option_name, dependency_type in mapping.items():
-        dependencies[dependency_type] = set()
-        for dep in options.get(option_name, []):
-            dependencies[dependency_type].add(
-                create_dependency_descriptor(dep))
+    _map_dependencies(mapping, options, dependencies)
 
     extras_mapping = {
         'test': 'test',
     }
-    extras_require = options.get('extras_require', {})
-    for option_name, dependency_type in extras_mapping.items():
-        for dep in extras_require.get(option_name, []):
+    _map_dependencies(
+        extras_mapping, options.get('extras_require', {}),
+        dependencies)
+
+    return dependencies
+
+
+def _map_dependencies(mapping, options, dependencies):
+    for option_name, dependency_type in mapping.items():
+        dependencies.setdefault(dependency_type, set())
+        for dep in options.get(option_name, []):
             dependencies[dependency_type].add(
                 create_dependency_descriptor(dep))
-    return dependencies
 
 
 def create_dependency_descriptor(requirement_string):

--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -80,6 +80,15 @@ def extract_dependencies(options):
         for dep in options.get(option_name, []):
             dependencies[dependency_type].add(
                 create_dependency_descriptor(dep))
+
+    extras_mapping = {
+        'test': 'test',
+    }
+    extras_require = options.get('extras_require', {})
+    for option_name, dependency_type in extras_mapping.items():
+        for dep in extras_require.get(option_name, []):
+            dependencies[dependency_type].add(
+                create_dependency_descriptor(dep))
     return dependencies
 
 

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -223,8 +223,8 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    tests_require = extract_dependencies(setup_py_data).get('test') or []
-    for d in tests_require:
+    tests_require = extract_dependencies(setup_py_data).get('test')
+    for d in tests_require or []:
         # the name might be followed by a version
         # separated by any of the following: ' ', <, >, <=, >=, ==, !=
         parts = re.split(r' |<|=|>|!', d)

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -222,8 +222,9 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    tests_require = setup_py_data.get('tests_require')
-    for d in tests_require or []:
+    tests_require = setup_py_data.get('tests_require', [])
+    tests_require += setup_py_data.get('extras_require', {}).get('test', [])
+    for d in tests_require:
         # the name might be followed by a version
         # separated by any of the following: ' ', <, >, <=, >=, ==, !=
         parts = re.split(r' |<|=|>|!', d)

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -6,6 +6,7 @@ import traceback
 
 from colcon_core.entry_point import load_entry_points
 from colcon_core.logging import colcon_logger
+from colcon_core.package_augmentation.python import extract_dependencies
 from colcon_core.plugin_system import get_first_line_doc
 from colcon_core.plugin_system import instantiate_extensions
 from colcon_core.plugin_system import order_extensions_by_priority
@@ -222,8 +223,7 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    tests_require = setup_py_data.get('tests_require') or []
-    tests_require += setup_py_data.get('extras_require', {}).get('test') or []
+    tests_require = extract_dependencies(setup_py_data).get('test') or []
     for d in tests_require:
         # the name might be followed by a version
         # separated by any of the following: ' ', <, >, <=, >=, ==, !=

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -222,8 +222,8 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    tests_require = setup_py_data.get('tests_require', [])
-    tests_require += setup_py_data.get('extras_require', {}).get('test', [])
+    tests_require = setup_py_data.get('tests_require') or []
+    tests_require += setup_py_data.get('extras_require', {}).get('test') or []
     for d in tests_require:
         # the name might be followed by a version
         # separated by any of the following: ' ', <, >, <=, >=, ==, !=

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -66,7 +66,9 @@ def test_identify():
             'tests_require = test == 2.0.0\n'
             'zip_safe = false\n'
             '[options.extras_require]\n'
-            'test = test2 == 3.0.0\n')
+            'test = test2 == 3.0.0\n'
+            'tests = test3\n'
+            'testing = test4\n')
         assert extension.identify(desc) is None
         assert desc.name == 'other-name'
         assert desc.type == 'python'
@@ -79,7 +81,7 @@ def test_identify():
         assert desc.dependencies['run'] == {'runA', 'runB'}
         dep = next(x for x in desc.dependencies['run'] if x == 'runA')
         assert dep.metadata['version_gt'] == '1.2.3'
-        assert desc.dependencies['test'] == {'test', 'test2'}
+        assert desc.dependencies['test'] == {'test', 'test2', 'test3', 'test4'}
 
         assert callable(desc.metadata['get_python_setup_options'])
         options = desc.metadata['get_python_setup_options'](None)

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -68,7 +68,8 @@ def test_identify():
             '[options.extras_require]\n'
             'test = test2 == 3.0.0\n'
             'tests = test3\n'
-            'testing = test4\n')
+            'testing = test4\n'
+            'other = not-test\n')
         assert extension.identify(desc) is None
         assert desc.name == 'other-name'
         assert desc.type == 'python'

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -64,7 +64,9 @@ def test_identify():
             '  runA > 1.2.3\n'
             '  runB\n'
             'tests_require = test == 2.0.0\n'
-            'zip_safe = false\n')
+            'zip_safe = false\n'
+            '[options.extras_require]\n'
+            'test = test2 == 3.0.0\n')
         assert extension.identify(desc) is None
         assert desc.name == 'other-name'
         assert desc.type == 'python'
@@ -77,7 +79,7 @@ def test_identify():
         assert desc.dependencies['run'] == {'runA', 'runB'}
         dep = next(x for x in desc.dependencies['run'] if x == 'runA')
         assert dep.metadata['version_gt'] == '1.2.3'
-        assert desc.dependencies['test'] == {'test'}
+        assert desc.dependencies['test'] == {'test', 'test2'}
 
         assert callable(desc.metadata['get_python_setup_options'])
         options = desc.metadata['get_python_setup_options'](None)

--- a/test/test_task_python_test_pytest.py
+++ b/test/test_task_python_test_pytest.py
@@ -9,7 +9,7 @@ from colcon_core.task.python.test.pytest import PytestPythonTestingStep
 
 def test_pytest_match():
     extension = PytestPythonTestingStep()
-    env = dict()
+    env = {}
     desc = PackageDescriptor('/dev/null')
     context = TaskContext(pkg=desc, args=None, dependencies=None)
 
@@ -17,7 +17,7 @@ def test_pytest_match():
     desc.type = 'python'
 
     # no test requirements
-    desc.metadata['get_python_setup_options'] = lambda env: dict()
+    desc.metadata['get_python_setup_options'] = lambda env: {}
     assert not extension.match(context, env, get_setup_data(desc, env))
 
     # pytest not in tests_require

--- a/test/test_task_python_test_pytest.py
+++ b/test/test_task_python_test_pytest.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.package_descriptor import PackageDescriptor
+from colcon_core.task import TaskContext
+from colcon_core.task.python import get_setup_data
+from colcon_core.task.python.test.pytest import PytestPythonTestingStep
+
+
+def test_pytest_match():
+    extension = PytestPythonTestingStep()
+    env = dict()
+    desc = PackageDescriptor('/dev/null')
+    context = TaskContext(pkg=desc, args=None, dependencies=None)
+
+    desc.name = 'pkg-name'
+    desc.type = 'python'
+
+    # no test requirements
+    desc.metadata['get_python_setup_options'] = lambda env: dict()
+    assert not extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest not in tests_require
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'tests_require': ['nose'],
+    }
+    assert not extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest not in extras_require.test
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'extras_require': {
+            'test': ['nose']
+        },
+    }
+    assert not extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest in tests_require
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'tests_require': ['pytest'],
+    }
+    assert extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest not in extras_require.test
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'extras_require': {
+            'test': ['pytest']
+        },
+    }
+    assert extension.match(context, env, get_setup_data(desc, env))

--- a/test/test_task_python_test_pytest.py
+++ b/test/test_task_python_test_pytest.py
@@ -40,7 +40,7 @@ def test_pytest_match():
     }
     assert extension.match(context, env, get_setup_data(desc, env))
 
-    # pytest not in extras_require.test
+    # pytest in extras_require.test
     desc.metadata['get_python_setup_options'] = lambda env: {
         'extras_require': {
             'test': ['pytest']


### PR DESCRIPTION
It's becoming an increasingly common pattern to declare test dependencies using [options.extras_require]test. This change merges the test dependencies declared using that mechanism with any discovered using [options]test_requires.

This is more-or-less a follow-up to #444.