### PR TITLE
Switch to unittest.mock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ test =
   flake8-docstrings
   flake8-import-order
   flake8-quotes
-  mock
   pep8-naming
   pylint
   pytest

--- a/test/test_argument_parser.py
+++ b/test/test_argument_parser.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0
 
 from argparse import ArgumentParser
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.argument_parser import ArgumentParserDecorator
 from colcon_core.argument_parser import ArgumentParserDecoratorExtensionPoint
 from colcon_core.argument_parser import decorate_argument_parser
 from colcon_core.argument_parser import get_argument_parser_extensions
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -5,6 +5,8 @@ import shutil
 import signal
 import sys
 from tempfile import mkdtemp
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.command import CommandContext
 from colcon_core.command import create_parser
@@ -12,8 +14,6 @@ from colcon_core.command import main
 from colcon_core.command import verb_main
 from colcon_core.environment_variable import EnvironmentVariable
 from colcon_core.verb import VerbExtensionPoint
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_entry_point.py
+++ b/test/test_entry_point.py
@@ -2,14 +2,14 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.entry_point import EXTENSION_POINT_GROUP_NAME
 from colcon_core.entry_point import get_all_entry_points
 from colcon_core.entry_point import get_entry_points
 from colcon_core.entry_point import load_entry_point
 from colcon_core.entry_point import load_entry_points
-from mock import Mock
-from mock import patch
 import pytest
 
 from .environment_context import EnvironmentContext

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -4,6 +4,8 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.environment import create_environment_hooks
 from colcon_core.environment import create_environment_scripts
@@ -11,8 +13,6 @@ from colcon_core.environment import EnvironmentExtensionPoint
 from colcon_core.environment import get_environment_extensions
 from colcon_core.shell import get_shell_extensions
 from colcon_core.shell import ShellExtensionPoint
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_environment_path.py
+++ b/test/test_environment_path.py
@@ -3,9 +3,9 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core.environment.path import PathEnvironment
-from mock import patch
 
 
 def test_path():

--- a/test/test_environment_pythonpath.py
+++ b/test/test_environment_pythonpath.py
@@ -4,9 +4,9 @@
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core.environment.pythonpath import PythonPathEnvironment
-from mock import patch
 
 
 def test_pythonpath():

--- a/test/test_event_handler.py
+++ b/test/test_event_handler.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0
 
 import argparse
+from unittest.mock import Mock
 
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.event_handler import apply_event_handler_arguments
 from colcon_core.event_handler import EventHandlerExtensionPoint
 from colcon_core.event_handler import format_duration
 from colcon_core.event_handler import get_event_handler_extensions
-from mock import Mock
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_event_handler_console_direct.py
+++ b/test/test_event_handler_console_direct.py
@@ -1,10 +1,11 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import patch
+
 from colcon_core.event.output import StderrLine
 from colcon_core.event.output import StdoutLine
 from colcon_core.event_handler.console_direct import ConsoleDirectEventHandler
-from mock import patch
 
 
 def test_console_direct():

--- a/test/test_event_handler_console_start_end.py
+++ b/test/test_event_handler_console_start_end.py
@@ -1,13 +1,14 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import patch
+
 from colcon_core.event.job import JobEnded
 from colcon_core.event.job import JobStarted
 from colcon_core.event.test import TestFailure
 from colcon_core.event_handler.console_start_end \
     import ConsoleStartEndEventHandler
 from colcon_core.subprocess import SIGINT_RESULT
-from mock import patch
 
 
 def test_console_start_end():

--- a/test/test_event_handler_log_command.py
+++ b/test/test_event_handler_log_command.py
@@ -1,10 +1,11 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import patch
+
 from colcon_core.event.command import Command
 from colcon_core.event.command import CommandEnded
 from colcon_core.event_handler.log_command import LogCommandEventHandler
-from mock import patch
 
 
 def test_console_direct():

--- a/test/test_event_reactor.py
+++ b/test/test_event_reactor.py
@@ -3,13 +3,13 @@
 
 from queue import Queue
 import time
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.event.timer import TimerEvent
 from colcon_core.event_handler import EventHandlerExtensionPoint
 from colcon_core.event_reactor import create_event_reactor
 from colcon_core.event_reactor import EventReactorShutdown
-from mock import Mock
-from mock import patch
 
 from .entry_point_context import EntryPointContext
 

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -3,6 +3,8 @@
 
 from argparse import ArgumentParser
 from asyncio import CancelledError
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.event.job import JobEnded
 from colcon_core.event.job import JobQueued
@@ -17,8 +19,6 @@ from colcon_core.executor import get_executor_extensions
 from colcon_core.executor import Job
 from colcon_core.executor import OnError
 from colcon_core.subprocess import SIGINT_RESULT
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -4,6 +4,7 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core import location
 from colcon_core.location import _create_symlink
@@ -12,7 +13,6 @@ from colcon_core.location import get_config_path
 from colcon_core.location import get_log_path
 from colcon_core.location import set_default_config_path
 from colcon_core.location import set_default_log_path
-from mock import patch
 import pytest
 
 from .environment_context import EnvironmentContext

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0
 
 import logging
+from unittest.mock import Mock
 
 from colcon_core.logging import get_numeric_log_level
 from colcon_core.logging import set_logger_level_from_env
-from mock import Mock
 import pytest
 
 from .environment_context import EnvironmentContext

--- a/test/test_package_augmentation.py
+++ b/test/test_package_augmentation.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.package_augmentation import augment_packages
 from colcon_core.package_augmentation \
@@ -10,8 +12,6 @@ from colcon_core.package_augmentation import PackageAugmentationExtensionPoint
 from colcon_core.package_augmentation import update_descriptor
 from colcon_core.package_augmentation import update_metadata
 from colcon_core.package_descriptor import PackageDescriptor
-from mock import Mock
-from mock import patch
 
 from .entry_point_context import EntryPointContext
 

--- a/test/test_package_decorator.py
+++ b/test/test_package_decorator.py
@@ -1,11 +1,12 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import Mock
+
 from colcon_core.package_decorator import add_recursive_dependencies
 from colcon_core.package_decorator import get_decorators
 from colcon_core.package_decorator import PackageDecorator
 from colcon_core.package_descriptor import PackageDescriptor
-from mock import Mock
 
 
 def test_constructor():

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -4,6 +4,8 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_discovery import _discover_packages
@@ -13,8 +15,6 @@ from colcon_core.package_discovery import discover_packages
 from colcon_core.package_discovery import expand_dir_wildcards
 from colcon_core.package_discovery import get_package_discovery_extensions
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
-from mock import Mock
-from mock import patch
 
 from .entry_point_context import EntryPointContext
 

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -4,12 +4,12 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_discovery.path import PathPackageDiscovery
 from colcon_core.package_identification import IgnoreLocationException
-from mock import Mock
-from mock import patch
 
 
 def test_path_package_discovery():

--- a/test/test_package_identification.py
+++ b/test/test_package_identification.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_identification import _identify
@@ -11,8 +13,6 @@ from colcon_core.package_identification import identify
 from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_package_identification_ignore.py
+++ b/test/test_package_identification_ignore.py
@@ -3,12 +3,12 @@
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from colcon_core.package_identification import IgnoreLocationException
 from colcon_core.package_identification.ignore import IGNORE_MARKER
 from colcon_core.package_identification.ignore \
     import IgnorePackageIdentification
-from mock import Mock
 import pytest
 
 

--- a/test/test_package_selection.py
+++ b/test/test_package_selection.py
@@ -3,6 +3,8 @@
 
 from argparse import Namespace
 import os
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.package_selection import _add_package_selection_arguments
@@ -12,8 +14,6 @@ from colcon_core.package_selection import get_package_selection_extensions
 from colcon_core.package_selection import get_packages
 from colcon_core.package_selection import PackageSelectionExtensionPoint
 from colcon_core.package_selection import select_package_decorators
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -1,6 +1,8 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import patch
+
 from colcon_core.plugin_system import get_first_line_doc
 from colcon_core.plugin_system import instantiate_extensions
 from colcon_core.plugin_system import order_extensions_by_name
@@ -8,7 +10,6 @@ from colcon_core.plugin_system import order_extensions_by_priority
 from colcon_core.plugin_system import order_extensions_grouped_by_priority
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_prefix_path.py
+++ b/test/test_prefix_path.py
@@ -4,13 +4,13 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.prefix_path import get_chained_prefix_path
 from colcon_core.prefix_path import get_prefix_path_extensions
 from colcon_core.prefix_path import PrefixPathExtensionPoint
 from colcon_core.prefix_path.colcon import ColconPrefixPath
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -5,6 +5,8 @@ from collections import OrderedDict
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_core.shell import check_dependency_availability
@@ -16,8 +18,6 @@ from colcon_core.shell import get_command_environment
 from colcon_core.shell import get_environment_variables
 from colcon_core.shell import get_shell_extensions
 from colcon_core.shell import ShellExtensionPoint
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_shell_template.py
+++ b/test/test_shell_template.py
@@ -4,10 +4,10 @@
 from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core.shell.template import expand_template
 from em import TransientParseError
-from mock import patch
 import pytest
 
 

--- a/test/test_shell_template_prefix_util.py
+++ b/test/test_shell_template_prefix_util.py
@@ -4,13 +4,13 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core.location import get_relative_package_index_path
 from colcon_core.shell.template.prefix_util import get_packages
 from colcon_core.shell.template.prefix_util import main
 from colcon_core.shell.template.prefix_util import order_packages
 from colcon_core.shell.template.prefix_util import reduce_cycle_set
-from mock import patch
 import pytest
 
 

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from colcon_core.event.command import Command
 from colcon_core.event.job import JobProgress
@@ -19,8 +21,6 @@ from colcon_core.task import install
 from colcon_core.task import run
 from colcon_core.task import TaskContext
 from colcon_core.task import TaskExtensionPoint
-from mock import Mock
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext

--- a/test/test_verb.py
+++ b/test/test_verb.py
@@ -5,13 +5,13 @@ import argparse
 import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from colcon_core.verb import check_and_mark_build_tool
 from colcon_core.verb import check_and_mark_install_layout
 from colcon_core.verb import get_verb_extensions
 from colcon_core.verb import update_object
 from colcon_core.verb import VerbExtensionPoint
-from mock import patch
 import pytest
 
 from .entry_point_context import EntryPointContext


### PR DESCRIPTION
The standalone 'mock' package is a [backport of unittest.mock from Python 3.3](https://pypi.org/project/mock/). All versions of Python that colcon supports have unittest.mock, so it's better to use that and drop the unnecessary test dependency.