### PR TITLE
Handle 'None' in options.extras_require

### DIFF
--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -83,7 +83,7 @@ def extract_dependencies(options):
         'testing': 'test',
     }
     _map_dependencies(
-        options.get('extras_require', {}), extras_mapping,
+        options.get('extras_require') or {}, extras_mapping,
         dependencies)
 
     return dependencies
@@ -92,7 +92,7 @@ def extract_dependencies(options):
 def _map_dependencies(options, mapping, dependencies):
     for option_name, dependency_type in mapping.items():
         dependencies.setdefault(dependency_type, set())
-        for dep in options.get(option_name, []):
+        for dep in options.get(option_name) or []:
             dependencies[dependency_type].add(
                 create_dependency_descriptor(dep))
 

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -46,7 +46,16 @@ def test_identify():
         assert extension.identify(desc) is None
         assert desc.name == 'pkg-name'
         assert desc.type == 'python'
+        assert not desc.dependencies
+        assert not desc.metadata
 
+        augmentation_extension.augment_package(desc)
+        assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
+        assert not desc.dependencies['build']
+        assert not desc.dependencies['run']
+        assert not desc.dependencies['test']
+
+        desc = PackageDescriptor(basepath)
         desc.name = 'other-name'
         with pytest.raises(RuntimeError) as e:
             extension.identify(desc)


### PR DESCRIPTION
I'm not sure the precise circumstances that lead to this, but I'm seeing 'None' coming out of options.extras_require entries in the wild.

Regression caused by #450