### PR TITLE
0.7.0

### DIFF
--- a/colcon_core/__init__.py
+++ b/colcon_core/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2016-2020 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-__version__ = '0.6.1'
+__version__ = '0.7.0'


### PR DESCRIPTION
There are a [considerable number of changes](https://github.com/colcon/colcon-core/milestone/49?closed=1) that have been merged into `colcon-core` since `0.6.1` was released, and I think we're ready to push `0.7.0` out the door.

Dirk, we'll need your help to make this happen. If you agree that we're ready for 0.7.0, I can merge this PR and tag the release in this repository, but I don't have sufficient rights on PyPI nor PackageCloud to distribute binaries. I'll need you to either build and push the release yourself or grant me (or someone else) the ability to do so.

Thanks!