### PR TITLE
Prevent branch CI from failing because of coverage changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,5 @@ coverage:
         informational: true
     patch:
       default:
+        only_pulls: true
         target: 0%


### PR DESCRIPTION
Computing coverage for a branch is important for comparing with pull requests, but getting a big fat X in the commit logs when the coverage decreases slightly or is noisy isn't helpful. Since the 'project' configuration is already marked as 'informational', it will still run for branch CI but won't cause the nasty red X if things aren't perfect.

The patch coverage information isn't really very useful on branch CI, so this PR suggests that we stop computing it except in PRs where we want a regression to be asserted.

Relevant docs: https://docs.codecov.com/docs/commit-status#only_pulls