### PR TITLE
Demote package override error to a warning

### DIFF
--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -200,7 +200,7 @@ class BuildVerb(VerbExtensionPoint):
                 ' '.join(sorted(override_messages.keys())))
 
             logger.warn(
-                override_msg + '\n\nThis will be promoted to an error in a'
+                override_msg + '\n\nThis may be promoted to an error in a'
                 ' future release of colcon-core.')
 
         on_error = OnError.interrupt \

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -198,7 +198,10 @@ class BuildVerb(VerbExtensionPoint):
                 ' line:'
                 '\n\t--allow-overriding ' +
                 ' '.join(sorted(override_messages.keys())))
-            raise RuntimeError(override_msg)
+
+            logger.warn(
+                override_msg + '\n\nThis will be promoted to an error in a'
+                ' future release of colcon-core.')
 
         on_error = OnError.interrupt \
             if not context.args.continue_on_error else OnError.skip_downstream


### PR DESCRIPTION
Overriding packages in underlay workspaces appears to be more common than originally believed, so it's a good idea to let the dust settle as a warning rather than breaking builds at this point.