### PR TITLE
Setup find_installed_packages to fix bootstrap instructions

### DIFF
--- a/bin/colcon
+++ b/bin/colcon
@@ -106,8 +106,8 @@ custom_entry_points.update({
         # since they can't be queried through pkg_resources without installing
     },
     'colcon_core.shell.find_installed_packages': {
-        'colcon_isolated' : IsolatedInstalledPackageFinder,
-        'colcon_merged' : MergedInstalledPackageFinder,
+        'colcon_isolated': IsolatedInstalledPackageFinder,
+        'colcon_merged': MergedInstalledPackageFinder,
     },
     'colcon_core.package_augmentation': {
         'python': PythonPackageAugmentation,

--- a/bin/colcon
+++ b/bin/colcon
@@ -65,10 +65,6 @@ from colcon_core.prefix_path.colcon import ColconPrefixPath  # noqa: E402
 from colcon_core.shell import ALL_SHELLS_ENVIRONMENT_VARIABLE  # noqa: E402
 from colcon_core.shell.bat import BatShell  # noqa: E402
 from colcon_core.shell.dsv import DsvShell  # noqa: E402
-from colcon_core.shell.installed_packages \
-    import IsolatedInstalledPackageFinder  # noqa: E402
-from colcon_core.shell.installed_packages \
-    import MergedInstalledPackageFinder  # noqa: E402
 from colcon_core.shell.sh import ShShell  # noqa: E402
 from colcon_core.task.python.build import PythonBuildTask  # noqa: E402
 from colcon_core.task.python.test import PythonTestTask  # noqa: E402
@@ -129,8 +125,7 @@ custom_entry_points.update({
         'sh': ShShell,
     },
     'colcon_core.shell.find_installed_packages': {
-        'colcon_isolated': IsolatedInstalledPackageFinder,
-        'colcon_merged': MergedInstalledPackageFinder,
+        # Not essential for bootstrapping
     },
     'colcon_core.task.build': {
         'python': PythonBuildTask,

--- a/bin/colcon
+++ b/bin/colcon
@@ -105,10 +105,6 @@ custom_entry_points.update({
         # there is no point in registering the extension_point extensions here
         # since they can't be queried through pkg_resources without installing
     },
-    'colcon_core.shell.find_installed_packages': {
-        'colcon_isolated': IsolatedInstalledPackageFinder,
-        'colcon_merged': MergedInstalledPackageFinder,
-    },
     'colcon_core.package_augmentation': {
         'python': PythonPackageAugmentation,
     },
@@ -131,6 +127,10 @@ custom_entry_points.update({
         'bat': BatShell,
         'dsv': DsvShell,
         'sh': ShShell,
+    },
+    'colcon_core.shell.find_installed_packages': {
+        'colcon_isolated': IsolatedInstalledPackageFinder,
+        'colcon_merged': MergedInstalledPackageFinder,
     },
     'colcon_core.task.build': {
         'python': PythonBuildTask,

--- a/bin/colcon
+++ b/bin/colcon
@@ -65,6 +65,10 @@ from colcon_core.prefix_path.colcon import ColconPrefixPath  # noqa: E402
 from colcon_core.shell import ALL_SHELLS_ENVIRONMENT_VARIABLE  # noqa: E402
 from colcon_core.shell.bat import BatShell  # noqa: E402
 from colcon_core.shell.dsv import DsvShell  # noqa: E402
+from colcon_core.shell.installed_packages \
+    import IsolatedInstalledPackageFinder  # noqa: E402
+from colcon_core.shell.installed_packages \
+    import MergedInstalledPackageFinder  # noqa: E402
 from colcon_core.shell.sh import ShShell  # noqa: E402
 from colcon_core.task.python.build import PythonBuildTask  # noqa: E402
 from colcon_core.task.python.test import PythonTestTask  # noqa: E402
@@ -100,6 +104,10 @@ custom_entry_points.update({
     'colcon_core.extension_point': {
         # there is no point in registering the extension_point extensions here
         # since they can't be queried through pkg_resources without installing
+    },
+    'colcon_core.shell.find_installed_packages': {
+        'colcon_isolated' : IsolatedInstalledPackageFinder,
+        'colcon_merged' : MergedInstalledPackageFinder,
     },
     'colcon_core.package_augmentation': {
         'python': PythonPackageAugmentation,


### PR DESCRIPTION
Fix an issue from #449 - the bootstrap from source instructions are failing with the following error

```
[0.267s] ERROR:colcon.colcon_core.shell:Exception in shell extension 'sh': get_entry_points() not overridden for group 'colcon_core.shell.find_installed_packages'
Traceback (most recent call last):
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/__init__.py", line 298, in get_command_environment
    return await extension.generate_command_environment(
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/sh.py", line 137, in generate_command_environment
    check_dependency_availability(
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/__init__.py", line 510, in check_dependency_availability
    packages_in_env = find_installed_packages_in_environment()
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/__init__.py", line 552, in find_installed_packages_in_environment
    pkgs = find_installed_packages(prefix_path)
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/__init__.py", line 621, in find_installed_packages
    prioritized_extensions = get_find_installed_packages_extensions()
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/shell/__init__.py", line 601, in get_find_installed_packages_extensions
    extensions = instantiate_extensions(__name__ + '.find_installed_packages')
  File "/home/sloretz/ws/colcon-from-source/src/colcon-core/colcon_core/plugin_system.py", line 36, in instantiate_extensions
    extension_types = load_entry_points(
  File "./src/colcon-core/bin/colcon", line 28, in custom_load_entry_points
    assert group_name in custom_entry_points, \
AssertionError: get_entry_points() not overridden for group 'colcon_core.shell.find_installed_packages'
```

I thought CI covered the bootstrap case, so I'm not sure why this wasn't caught.