### PR TITLE
Don't warn about overriding when building the a workspace that has al…

### DIFF
--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -162,6 +162,10 @@ class BuildVerb(VerbExtensionPoint):
 
         underlay_packages = {}
         for prefix_path in get_chained_prefix_path():
+            if prefix_path == install_base:
+                # The install space of the workspace being built is sourced
+                # Ignore it for the purposes of the override warning
+                continue
             packages = find_installed_packages(Path(prefix_path))
             if packages:
                 for pkg, path in packages.items():


### PR DESCRIPTION
Requires #472 (currently targeting that PR's branch)
Resolves #465

If a user builds a workspace, sources the install space, then builds again the override warning was triggering. This PR avoids warning in that case. It does so by ignoring the install space of the current workspace when looking for packages in underlay's. 