### PR TITLE
Fix the bootstrap test in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,13 +45,14 @@ jobs:
         run: |
           python -m pip install -U pip setuptools
           python -m pip install -U -e .[test]
+          python -m pip uninstall -y colcon-core
       - name: Build and test
-        env:
-          COLCON_ALL_SHELLS: 'TRUE'
         run: |
-          python bin/colcon build --build-base ../build --install-base ../install
-          python bin/colcon test --build-base ../build --install-base ../install
+          cd ..
+          python ${{github.workspace}}/bin/colcon build --paths ${{github.workspace}}
+          python ${{github.workspace}}/bin/colcon test --paths ${{github.workspace}} --return-code-on-test-failure
       - name: Use the installed package (Bash)
+        if: ${{runner.os != 'windows'}}
         shell: bash
         run: |
           . ../install/local_setup.sh


### PR DESCRIPTION
Installing the test dependencies like this also enables importing from the package itself, which is contrary to the bootstrapping scenario we're trying to test. Simplest solution is to specifically uninstall it again, which should leave all of the dependencies in place.

Additionally, the test results during the bootstrap build were not causing the action to fail, and were therefore being ignored.

Furthermore, it appears that the `COLCON_ALL_SHELLS` variable is not sufficient to generate usable bash hooks on Windows, so I'm disabling the bash test until we can come up with a good way to support it. It wasn't tested in the old Travis tests, and documentation suggests that it isn't a supported scenario anyway.

Lastly, while in the package root, it's possible to perform imports from colcon_core as if it were already installed. The bootstrap scenario doesn't necessitate running from the repository root, so the test shouldn't do so either.