### PR TITLE
Move the package package override checks out of colcon-core

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -95,9 +95,7 @@ setupscript
 setuptools
 shlex
 sigint
-sloretz
 stacklevel
-stackoverflow
 staticmethod
 stdeb
 stringify
@@ -124,4 +122,3 @@ unlinking
 unrenamed
 wildcards
 workaround
-workspaces


### PR DESCRIPTION
This functionality is being moved to a separate colcon extension, [colcon-override-check](https://github.com/colcon/colcon-override-check).

Reverts part of #449