### PR TITLE
Add ActionCollectorDecorator, deprecate TypeCollectorDecorator

### DIFF
--- a/colcon_core/argument_parser/action_collector.py
+++ b/colcon_core/argument_parser/action_collector.py
@@ -1,0 +1,114 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.argument_parser import ArgumentParserDecorator
+
+
+class ActionCollectorDecorator(ArgumentParserDecorator):
+    """Collect actions for all added arguments."""
+
+    def __init__(self, parser, **kwargs):
+        """
+        Construct a ActionCollectorDecorator.
+
+        :param parser: The argument parser to decorate
+        """
+        # avoid setting members directly, the base class overrides __setattr__
+        # pass them as keyword arguments instead
+        super().__init__(
+            parser,
+            _collected_actions=set(),
+            **kwargs)
+
+    def get_collected_actions(self):
+        """
+        Get actions for all added arguments.
+
+        :returns: The argument actions
+        :rtype: dict
+        """
+        return set(self._collected_actions)
+
+    def add_argument(self, *args, **kwargs):
+        """Collect actions for all added arguments."""
+        action = super().add_argument(*args, **kwargs)
+        self._collected_actions.add(action)
+        return action
+
+
+class SuppressRequiredActions:
+    """
+    Context manager to suppress required actions during `parse_known_args`.
+
+    This works only with parsers decorated with
+    :class:`ActionCollectorDecorator`. It operates by temporarily
+    setting the ``required`` attribute on all actions to ``False``, then
+    restores the original behavior when exiting.
+    """
+
+    def __init__(self, parsers, actions_to_omit=None):
+        """
+        Construct a SuppressRequiredActions.
+
+        :param parsers: The parsers
+        :param actions_to_omit: A collection of actions which should not be
+          suppressed
+        """
+        self._parsers = parsers
+        self._suppressed_actions = set()
+        self._actions_to_omit = actions_to_omit or set()
+
+    def __enter__(self):  # noqa: D105
+        for p in self._parsers:
+            if not issubclass(type(p), ActionCollectorDecorator):
+                continue
+            for action in p.get_collected_actions():
+                if not action.required:
+                    continue
+                if action in self._actions_to_omit:
+                    continue
+                self._suppressed_actions.add(action)
+                action.required = False
+
+    def __exit__(self, *args):  # noqa: D105
+        for action in self._suppressed_actions:
+            action.required = True
+
+
+class SuppressTypeConversions:
+    """
+    Context manager to suppress type conversions during `parse_known_args`.
+
+    This works only with parsers decorated with
+    :class:`ActionCollectorDecorator`. It operates by temporarily
+    setting the ``type`` attribute on all actions to ``None``, then
+    restores the original conversion when exiting.
+    """
+
+    def __init__(self, parsers, actions_to_omit=None):
+        """
+        Construct a SuppressTypeConversions.
+
+        :param parsers: The parsers
+        :param actions_to_omit: A collection of actions which should not be
+          suppressed
+        """
+        self._parsers = parsers
+        self._suppressed_actions = {}
+        self._actions_to_omit = actions_to_omit or set()
+
+    def __enter__(self):  # noqa: D105
+        for p in self._parsers:
+            if not issubclass(type(p), ActionCollectorDecorator):
+                continue
+            for action in p.get_collected_actions():
+                if action.type in (None, str):
+                    continue
+                if action in self._actions_to_omit:
+                    continue
+                self._suppressed_actions[action] = action.type
+                action.type = None
+
+    def __exit__(self, *args):  # noqa: D105
+        for action, original_type in self._suppressed_actions.items():
+            action.type = original_type

--- a/colcon_core/argument_parser/type_collector.py
+++ b/colcon_core/argument_parser/type_collector.py
@@ -1,11 +1,18 @@
 # Copyright 2021 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+import warnings
+
 from colcon_core.argument_parser import ArgumentParserDecorator
 
 
 class TypeCollectorDecorator(ArgumentParserDecorator):
     """Collect the type conversions of arguments."""
+
+    warnings.warn(
+        "'colcon_core.argument_parser.type_collector."
+        "TypeCollectorDecorator' has been deprecated",
+        stacklevel=2)
 
     def __init__(self, parser, **kwargs):
         """
@@ -61,6 +68,12 @@ class SuppressTypeConversions:
     conversion function (`str()`) in place of the original conversion, then
     restores the original conversion when exiting.
     """
+
+    warnings.warn(
+        "'colcon_core.argument_parser.type_collector."
+        "SuppressTypeConversions' has been deprecated, use 'colcon_core."
+        "argument_parser.action_collector.SuppressTypeConversions' "
+        'instead', stacklevel=2)
 
     def __init__(self, parsers, types_to_omit=None):
         """

--- a/test/test_action_collector.py
+++ b/test/test_action_collector.py
@@ -1,0 +1,142 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+import sys
+
+from colcon_core.argument_parser.action_collector \
+    import ActionCollectorDecorator
+from colcon_core.argument_parser.action_collector \
+    import SuppressRequiredActions
+from colcon_core.argument_parser.action_collector \
+    import SuppressTypeConversions
+import pytest
+
+
+class _RaisingArgumentParser(argparse.ArgumentParser):
+
+    def error(self, message):
+        raise sys.exc_info()[1] or Exception(message)
+
+
+def test_action_collector_decorator():
+    parser = argparse.ArgumentParser()
+    decorator = ActionCollectorDecorator(parser)
+    a = decorator.add_argument('positional')
+    assert decorator.get_collected_actions() == {a}
+
+    b = decorator.add_argument('--option', type=bool)
+    assert decorator.get_collected_actions() == {a, b}
+
+
+def test_suppress_required_actions():
+    parser = _RaisingArgumentParser()
+    decorator = ActionCollectorDecorator(parser)
+    pos1 = decorator.add_argument('pos1')
+    decorator.add_argument('pos2', nargs='?')
+
+    args = parser.parse_args(['foo', 'bar'])
+    assert 'foo' == args.pos1
+    assert 'bar' == args.pos2
+
+    with SuppressRequiredActions((decorator,)):
+        parser.parse_args([])
+    with pytest.raises(Exception):
+        parser.parse_args([])
+    with pytest.raises(Exception):
+        with SuppressRequiredActions((decorator,), {pos1}):
+            parser.parse_args([])
+
+    args = parser.parse_args(['foo', 'bar'])
+    assert 'foo' == args.pos1
+    assert 'bar' == args.pos2
+
+
+def test_suppress_type_conversions():
+    parser = _RaisingArgumentParser()
+    decorator = ActionCollectorDecorator(parser)
+    action_f = decorator.add_argument('-f', type=float)
+    action_i = decorator.add_argument('-i', type=int)
+    decorator.register('action', 'not_implemented', argparse.Action)
+    decorator.register('type', 'hex', float.fromhex)
+    action_x = decorator.add_argument('-x', type='hex', default=None)
+    decorator.add_argument('-s')
+
+    args = parser.parse_args(['-f', '3.14', '-i', '1', '-x', '0x42'])
+    assert 3.14 == args.f
+    assert 1 == args.i
+    assert 0x42 == args.x
+
+    with SuppressTypeConversions((decorator,)):
+        parser.parse_args(['-f', 'bar', '-i', '1', '-x', '0x42'])
+    with pytest.raises(argparse.ArgumentError):
+        parser.parse_args(['-f', 'bar', '-i', '1', '-x', '0x42'])
+    with pytest.raises(argparse.ArgumentError):
+        with SuppressTypeConversions((decorator,), {action_f}):
+            parser.parse_args(['-f', 'bar', '-i', '1', '-x', '0x42'])
+
+    with SuppressTypeConversions((decorator,)):
+        parser.parse_args(['-f', '3.14', '-i', 'bar', '-x', '0x42'])
+    with pytest.raises(argparse.ArgumentError):
+        parser.parse_args(['-f', '3.14', '-i', 'bar', '-x', '0x42'])
+    with pytest.raises(argparse.ArgumentError):
+        with SuppressTypeConversions((decorator,), {action_i}):
+            parser.parse_args(['-f', '3.14', '-i', 'bar', '-x', '0x42'])
+
+    with SuppressTypeConversions((decorator,)):
+        parser.parse_args(['-f', '3.14', '-i', '1', '-x', 'foo'])
+    with pytest.raises(argparse.ArgumentError):
+        parser.parse_args(['-f', '3.14', '-i', '1', '-x', 'foo'])
+    with pytest.raises(argparse.ArgumentError):
+        with SuppressTypeConversions((decorator,), {action_x}):
+            parser.parse_args(['-f', '3.14', '-i', '1', '-x', 'foo'])
+
+    args = parser.parse_args(['-f', '3.14', '-i', '1', '-x', '0x42'])
+    assert 3.14 == args.f
+    assert 1 == args.i
+    assert 0x42 == args.x
+
+
+def test_suppress_required_actions_not_decorated():
+    parser = _RaisingArgumentParser()
+    parser.add_argument('pos1')
+    parser.add_argument('pos2', nargs='?')
+
+    args = parser.parse_args(['foo'])
+    assert 'foo' == args.pos1
+    with pytest.raises(Exception):
+        parser.parse_args([])
+
+    with SuppressRequiredActions((parser,)):
+        args = parser.parse_args(['foo'])
+    assert 'foo' == args.pos1
+    with pytest.raises(Exception):
+        with SuppressRequiredActions((parser,)):
+            parser.parse_args([])
+
+    args = parser.parse_args(['foo'])
+    assert 'foo' == args.pos1
+    with pytest.raises(Exception):
+        parser.parse_args([])
+
+
+def test_suppress_type_conversion_not_decorated():
+    parser = _RaisingArgumentParser()
+    parser.add_argument('-f', type=float)
+    parser.add_argument('-i', type=int)
+    parser.register('action', 'not_implemented', argparse.Action)
+    parser.register('type', 'hex', float.fromhex)
+    parser.add_argument('-x', type='hex', default=None)
+
+    args = parser.parse_args(['-f', '3.14', '-i', '1', '-x', '0x42'])
+    assert 3.14 == args.f
+    assert 1 == args.i
+    assert 0x42 == args.x
+
+    with SuppressTypeConversions((parser,)):
+        parser.parse_args(['-f', '3.14', '-i', '1', '-x', '0x42'])
+
+    args = parser.parse_args(['-f', '3.14', '-i', '1', '-x', '0x42'])
+    assert 3.14 == args.f
+    assert 1 == args.i
+    assert 0x42 == args.x

--- a/test/test_type_collector.py
+++ b/test/test_type_collector.py
@@ -3,10 +3,19 @@
 
 import argparse
 import sys
+import warnings
 
-from colcon_core.argument_parser.type_collector import SuppressTypeConversions
-from colcon_core.argument_parser.type_collector import TypeCollectorDecorator
 import pytest
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        'ignore', message='.*deprecated.*', category=UserWarning,
+        module='colcon_core.argument_parser.type_collector')
+
+    from colcon_core.argument_parser.type_collector \
+        import SuppressTypeConversions  # noqa: E402
+    from colcon_core.argument_parser.type_collector \
+        import TypeCollectorDecorator  # noqa: E402
 
 
 class _RaisingArgumentParser(argparse.ArgumentParser):


### PR DESCRIPTION
This change introduces a new decorator which replaces the `TypeCollectorDecorator`. Enumerating the actions returned by calls to `add_argument` is a cleaner and more efficient way to implement the `SuppressTypeConversions` functionality.

Additionally, this change adds a new suppression class for loosening argument requirements during pre-parsing operations. The `SuppressRequiredActions` class also utilizes the new `ActionCollectorDecorator`.

The motivation for the `SuppressRequiredActions` class (and therefore the `ActionCollectorDecorator`) is that pre-parsing in colcon-defaults and colcon-mixin is causing the error message for missing required arguments to take precedence over the full help text.

For example, invoke the `colcon metadata remove` command without the required positional argument:
```
$ colcon metadata remove --help
usage: colcon metadata remove [-h] name
colcon metadata remove: error: the following arguments are required: name
```

Without `colcon-metadata` and `colcon-defaults`, this works correctly:
```
$ export COLCON_EXTENSION_BLOCKLIST=colcon_core.argument_parser.colcon:colcon_core.argument_parser.mixin
$ colcon metadata remove --help
usage: colcon metadata remove [-h] name

Remove a repository from the list of indexes.

positional arguments:
  name        The unique name identifying the repository

options:
  -h, --help  show this help message and exit
```