### PR TITLE
Require Python 3.6, use f-strings

### DIFF
--- a/bin/colcon
+++ b/bin/colcon
@@ -26,8 +26,7 @@ custom_entry_points = {}
 def custom_load_entry_points(group_name, *, exclude_names=None):  # noqa: D103
     global custom_entry_points
     assert group_name in custom_entry_points, \
-        "get_entry_points() not overridden for group '{group_name}'" \
-        .format_map(locals())
+        f"get_entry_points() not overridden for group '{group_name}'"
     return {
         k: v for k, v in custom_entry_points[group_name].items()
         if exclude_names is None or k not in exclude_names}

--- a/colcon_core/argument_parser/__init__.py
+++ b/colcon_core/argument_parser/__init__.py
@@ -77,8 +77,7 @@ def decorate_argument_parser(parser):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in argument parser decorator extension '
-                "'{extension.ARGUMENT_PARSER_DECORATOR_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.ARGUMENT_PARSER_DECORATOR_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
         else:
             parser = decorated_parser

--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -36,14 +36,14 @@ if warnings_filters:
             category = warnings._getcategory(category)
         except Exception:  # noqa: B902
             print(
-                "The category field '{category}' must be a valid warnings "
-                'class name'.format_map(locals()), file=sys.stderr)
+                f"The category field '{category}' must be a valid warnings "
+                'class name', file=sys.stderr)
             sys.exit(1)
         if module:
             print(
-                'The module field of the {WARNINGS_ENVIRONMENT_VARIABLE.name} '
-                'filter should be empty, otherwise use PYTHONWARNINGS instead'
-                .format_map(locals()), file=sys.stderr)
+                'The module field of the '
+                f'{WARNINGS_ENVIRONMENT_VARIABLE.name} filter should be '
+                'empty, otherwise use PYTHONWARNINGS instead', file=sys.stderr)
             sys.exit(1)
         warnings.filterwarnings(
             action, message=message, category=category or Warning,
@@ -130,16 +130,15 @@ def _main(*, command_name, argv):
     # default log level, for searchability: COLCON_LOG_LEVEL
     colcon_logger.setLevel(logging.WARNING)
     set_logger_level_from_env(
-        colcon_logger, '{command_name}_LOG_LEVEL'.format_map(locals()).upper())
+        colcon_logger, f'{command_name}_LOG_LEVEL'.upper())
     colcon_logger.debug(
         'Command line arguments: {argv}'
         .format(argv=argv if argv is not None else sys.argv))
 
     # set default locations for config files, for searchability: COLCON_HOME
     set_default_config_path(
-        path=(
-            Path('~') / '.{command_name}'.format_map(locals())).expanduser(),
-        env_var='{command_name}_HOME'.format_map(locals()).upper())
+        path=(Path('~') / f'.{command_name}').expanduser(),
+        env_var=f'{command_name}_HOME'.upper())
 
     parser = create_parser('colcon_core.environment_variable')
 
@@ -165,8 +164,7 @@ def _main(*, command_name, argv):
         # the value might be provided externally and needs to be checked again
         colcon_logger.setLevel(get_numeric_log_level(args.log_level))
 
-    colcon_logger.debug(
-        'Parsed command line arguments: {args}'.format_map(locals()))
+    colcon_logger.debug(f'Parsed command line arguments: {args}')
 
     # error: no verb provided
     if args.verb_name is None:
@@ -178,8 +176,8 @@ def _main(*, command_name, argv):
     now_str = str(now)[:-7].replace(' ', '_').replace(':', '-')
     set_default_log_path(
         base_path=args.log_base,
-        env_var='{command_name}_LOG_PATH'.format_map(locals()).upper(),
-        subdirectory='{args.verb_name}_{now_str}'.format_map(locals()))
+        env_var=f'{command_name}_LOG_PATH'.upper(),
+        subdirectory=f'{args.verb_name}_{now_str}')
 
     # add a file handler writing all levels if logging isn't disabled
     log_path = get_log_path()
@@ -196,8 +194,7 @@ def _main(*, command_name, argv):
         handler.handle(log_record)
         log_record = colcon_logger.makeRecord(
             colcon_logger.name, logging.DEBUG, __file__, 0,
-            'Parsed command line arguments: {args}'.format_map(locals()),
-            None, None)
+            f'Parsed command line arguments: {args}', None, None)
         handler.handle(log_record)
 
     # set an environment variable named after the command (if not already set)
@@ -311,7 +308,7 @@ def add_log_level_argument(parser):
     parser.add_argument(
         '--log-base',
         help='The base path for all log directories (default: ./log, to '
-             'disable: {os.devnull})'.format_map(globals()))
+             f'disable: {os.devnull})')
     parser.add_argument(
         '--log-level', action=LogLevelAction,
         help='Set log level for the console output, either by numeric or '
@@ -332,9 +329,7 @@ class LogLevelAction(argparse.Action):
         try:
             value = get_numeric_log_level(values)
         except ValueError as e:  # noqa: F841
-            parser.error(
-                '{option_string} has unsupported value, {e}'
-                .format_map(locals()))
+            parser.error(f'{option_string} has unsupported value, {e}')
         setattr(namespace, self.dest, value)
 
 
@@ -391,11 +386,10 @@ def create_subparser(parser, cmd_name, verb_extensions, *, attribute):
 
     # add subparser with description of verb extensions
     subparser = parser.add_subparsers(
-        title='{cmd_name} verbs'.format_map(locals()),
+        title=f'{cmd_name} verbs',
         description='\n'.join(verbs),
         dest=attribute,
-        help='call `{cmd_name} VERB -h` for specific help'
-             .format_map(locals())
+        help=f'call `{cmd_name} VERB -h` for specific help',
     )
     return subparser
 
@@ -445,8 +439,8 @@ def add_parser_arguments(verb_parser, extension):
         retval = extension.add_arguments(parser=verb_parser)
         if retval is not None:
             colcon_logger.error(
-                "Exception in verb extension '{extension.VERB_NAME}': "
-                'add_arguments() should return None'.format_map(locals()))
+                f"Exception in verb extension '{extension.VERB_NAME}': "
+                'add_arguments() should return None')
 
 
 def _format_pair(key, value, *, indent, align):
@@ -528,15 +522,12 @@ def verb_main(context, logger):
         rc = context.args.main(context=context)
     except RuntimeError as e:  # noqa: F841
         # only log the error message for "known" exceptions
-        logger.error(
-            '{context.command_name} {context.args.verb_name}: {e}'
-            .format_map(locals()))
+        logger.error(f'{context.command_name} {context.args.verb_name}: {e}')
         return 1
     except Exception as e:  # noqa: F841
         # log the error message and a traceback for "unexpected" exceptions
         exc = traceback.format_exc()
         logger.error(
-            '{context.command_name} {context.args.verb_name}: {e}\n{exc}'
-            .format_map(locals()))
+            f'{context.command_name} {context.args.verb_name}: {e}\n{exc}')
         return 1
     return rc

--- a/colcon_core/entry_point.py
+++ b/colcon_core/entry_point.py
@@ -73,9 +73,9 @@ def get_all_entry_points():
                 if entry_point_name in entry_points[group_name]:
                     previous = entry_points[group_name][entry_point_name]
                     logger.error(
-                        "Entry point '{group_name}.{entry_point_name}' is "
-                        "declared multiple times, '{entry_point}' overwriting "
-                        "'{previous}'".format_map(locals()))
+                        f"Entry point '{group_name}.{entry_point_name}' is "
+                        f"declared multiple times, '{entry_point}' "
+                        f"overwriting '{previous}'")
                 entry_points[group_name][entry_point_name] = \
                     (dist, entry_point)
     return entry_points
@@ -96,9 +96,9 @@ def get_entry_points(group_name):
         if entry_point.name in entry_points:
             previous_entry_point = entry_points[entry_point.name]
             logger.error(
-                "Entry point '{group_name}.{entry_point.name}' is declared "
-                "multiple times, '{entry_point}' overwriting "
-                "'{previous_entry_point}'".format_map(locals()))
+                f"Entry point '{group_name}.{entry_point.name}' is declared "
+                f"multiple times, '{entry_point}' overwriting "
+                f"'{previous_entry_point}'")
         entry_points[entry_point.name] = entry_point
     return entry_points
 
@@ -125,8 +125,7 @@ def load_entry_points(group_name, *, exclude_names=None):
             exc = traceback.format_exc()
             logger.error(
                 'Exception loading extension '
-                "'{group_name}.{entry_point.name}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{group_name}.{entry_point.name}': {e}\n{exc}")
             # skip failing entry point, continue with next one
             continue
         extension_types[entry_point.name] = extension_type
@@ -158,11 +157,10 @@ def load_entry_point(entry_point):
         if entry_point.group_name in blocklist:
             raise RuntimeError(
                 'The entry point group name is listed in the environment '
-                "variable '{env_var_name}'".format_map(locals()))
-        full_name = '{entry_point.group_name}.{entry_point.name}' \
-            .format_map(locals())
+                f"variable '{env_var_name}'")
+        full_name = f'{entry_point.group_name}.{entry_point.name}'
         if full_name in blocklist:
             raise RuntimeError(
                 'The entry point name is listed in the environment variable '
-                "'{env_var_name}'".format_map(locals()))
+                f"'{env_var_name}'")
     return entry_point.load()

--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -136,8 +136,8 @@ def create_environment_scripts_only(
                 # catch exceptions raised in shell extension
                 exc = traceback.format_exc()
                 logger.error(
-                    "Exception in shell extension '{extension.SHELL_NAME}': "
-                    '{e}\n{exc}'.format_map(locals()))
+                    f"Exception in shell extension '{extension.SHELL_NAME}': "
+                    f'{e}\n{exc}')
                 # skip failing extension, continue with next one
 
 
@@ -180,8 +180,7 @@ def create_environment_hooks(prefix_path, pkg_name):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in environment extension '
-                "'{extension.ENVIRONMENT_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.ENVIRONMENT_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
             continue
         all_hooks += hooks

--- a/colcon_core/event/command.py
+++ b/colcon_core/event/command.py
@@ -33,7 +33,7 @@ class Command:
         The message includes the working directory, modifications to
         environment variable and the command including the arguments.
         """
-        string = "Invoking command in '{self.cwd}': ".format_map(locals())
+        string = f"Invoking command in '{self.cwd}': "
         string += self._get_env_string()
         string += self._get_cmd_string()
         return string
@@ -77,7 +77,7 @@ class Command:
         if env:
             for name in sorted(env.keys()):
                 value = env[name]
-                string += '{name}={value} '.format_map(locals())
+                string += f'{name}={value} '
         return string
 
     def _get_cmd_string(self):
@@ -106,8 +106,8 @@ class CommandEnded(Command):
 
     def to_string(self):
         """Get a string describing the invoked command and its return code."""
-        string = "Invoked command in '{self.cwd}' returned " \
-            "'{self.returncode}': ".format_map(locals())
+        string = f"Invoked command in '{self.cwd}' returned " \
+            f"'{self.returncode}': "
         string += self._get_env_string()
         string += self._get_cmd_string()
         return string

--- a/colcon_core/event_handler/__init__.py
+++ b/colcon_core/event_handler/__init__.py
@@ -81,7 +81,7 @@ def add_event_handler_arguments(parser):
         # since they are already listed in the defaults
         if desc:
             # it requires a custom formatter to maintain the newline
-            descriptions += '\n* {key}: {desc}'.format_map(locals())
+            descriptions += f'\n* {key}: {desc}'
 
     argument = group.add_argument(
         '--event-handlers',
@@ -125,8 +125,7 @@ def format_duration(seconds, *, fixed_decimal_points=None):
     """
     if seconds < 0.0:
         raise ValueError(
-            "The duration '{seconds}' must be a non-negative number"
-            .format_map(locals()))
+            f"The duration '{seconds}' must be a non-negative number")
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
 
@@ -154,9 +153,9 @@ def format_duration(seconds, *, fixed_decimal_points=None):
         minutes = 0.0
         hours += 1
 
-    format_string = '{seconds:.%sf}s' % decimal_points
+    format_string = f'{seconds:.{decimal_points}f}s'
     if hours or minutes:
-        format_string = '{minutes:.0f}min ' + format_string
+        format_string = f'{minutes:.0f}min ' + format_string
         if hours:
-            format_string = '{hours:.0f}h ' + format_string
-    return format_string.format_map(locals())
+            format_string = f'{hours:.0f}h ' + format_string
+    return format_string

--- a/colcon_core/event_handler/console_start_end.py
+++ b/colcon_core/event_handler/console_start_end.py
@@ -34,9 +34,7 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
         data = event[0]
 
         if isinstance(data, JobStarted):
-            print(
-                'Starting >>> {data.identifier}'.format_map(locals()),
-                flush=True)
+            print(f'Starting >>> {data.identifier}', flush=True)
             self._start_times[data.identifier] = time.monotonic()
 
         elif isinstance(data, TestFailure):
@@ -48,22 +46,19 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
                 time.monotonic() - self._start_times[data.identifier]
             duration_string = format_duration(duration)
             if not data.rc:
-                msg = 'Finished <<< {data.identifier} [{duration_string}]' \
-                    .format_map(locals())
+                msg = f'Finished <<< {data.identifier} [{duration_string}]'
                 job = event[1]
                 if job in self._with_test_failures:
                     msg += '\t[ with test failures ]'
                 writable = sys.stdout
 
             elif data.rc == SIGINT_RESULT:
-                msg = 'Aborted  <<< {data.identifier} [{duration_string}]' \
-                    .format_map(locals())
+                msg = f'Aborted  <<< {data.identifier} [{duration_string}]'
                 writable = sys.stdout
 
             else:
-                msg = 'Failed   <<< {data.identifier} ' \
-                    '[{duration_string}, exited with code {data.rc}]' \
-                    .format_map(locals())
+                msg = f'Failed   <<< {data.identifier} ' \
+                    f'[{duration_string}, exited with code {data.rc}]'
                 writable = sys.stderr
 
             print(msg, file=writable, flush=True)

--- a/colcon_core/event_reactor.py
+++ b/colcon_core/event_reactor.py
@@ -80,8 +80,7 @@ class EventReactor:
             except Exception as e:  # noqa: F841
                 # catch exceptions raised in event handler extension
                 msg = 'Exception in event handler extension ' \
-                    "'{observer.EVENT_HANDLER_NAME}': {e}" \
-                    .format_map(locals())
+                    f"'{observer.EVENT_HANDLER_NAME}': {e}"
                 if not isinstance(e, RuntimeError):
                     msg += '\n' + traceback.format_exc()
                 logger.error(msg)

--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -234,7 +234,7 @@ def add_executor_arguments(parser):
                 # to mention the available options
                 desc = '<no description>'
             # it requires a custom formatter to maintain the newline
-            descriptions += '\n* {key}: {desc}'.format_map(locals())
+            descriptions += f'\n* {key}: {desc}'
     assert keys, 'No executor extensions found'
 
     default = os.environ.get(DEFAULT_EXECUTOR_ENVIRONMENT_VARIABLE.name)
@@ -243,8 +243,8 @@ def add_executor_arguments(parser):
 
     group.add_argument(
         '--executor', type=str, choices=keys, default=default,
-        help='The executor to process all packages (default: {default})'
-             '{descriptions}'.format_map(locals()))
+        help=f'The executor to process all packages (default: {default})'
+             f'{descriptions}')
 
     for priority in extensions.keys():
         extensions_same_prio = extensions[priority]
@@ -257,8 +257,7 @@ def add_executor_arguments(parser):
                 exc = traceback.format_exc()
                 logger.error(
                     'Exception in executor extension '
-                    "'{extension.EXECUTOR_NAME}': {e}\n{exc}"
-                    .format_map(locals()))
+                    f"'{extension.EXECUTOR_NAME}': {e}\n{exc}")
                 # skip failing extension, continue with next one
 
 
@@ -325,9 +324,8 @@ def execute_jobs(
             # fallback to legacy API
             assert 'abort_on_error' in signature.parameters
             warnings.warn(
-                "The ExecutorExtensionPoint '{executor.EXECUTOR_NAME}' uses a "
-                "deprecated signature for the 'execute' method"
-                .format_map(locals()))
+                f"The ExecutorExtensionPoint '{executor.EXECUTOR_NAME}' uses "
+                "a deprecated signature for the 'execute' method")
             kwargs['abort_on_error'] = on_error == OnError.interrupt
 
         try:
@@ -336,8 +334,8 @@ def execute_jobs(
             # catch exceptions raised in executor extension
             exc = traceback.format_exc()
             logger.error(
-                "Exception in executor extension '{executor.EXECUTOR_NAME}': "
-                '{e}\n{exc}'.format_map(locals()))
+                f"Exception in executor extension '{executor.EXECUTOR_NAME}': "
+                f'{e}\n{exc}')
             rc = 1
         finally:
             # generate an event for every skipped job

--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -44,40 +44,32 @@ class SequentialExecutor(ExecutorExtensionPoint):
                 coro = job()
                 future = asyncio.ensure_future(coro, loop=loop)
                 try:
-                    logger.debug(
-                        "run_until_complete '{name}'".format_map(locals()))
+                    logger.debug(f"run_until_complete '{name}'")
                     loop.run_until_complete(future)
                 except KeyboardInterrupt:
                     logger.debug(
-                        "run_until_complete '{name}' was interrupted"
-                        .format_map(locals()))
+                        f"run_until_complete '{name}' was interrupted")
                     # override job rc with special SIGINT value
                     job.returncode = SIGINT_RESULT
                     # ignore further SIGINTs
                     signal.signal(signal.SIGINT, signal.SIG_IGN)
                     # wait for job which has also received a SIGINT
                     if not future.done():
-                        logger.debug(
-                            "run_until_complete '{name}' again"
-                            .format_map(locals()))
+                        logger.debug(f"run_until_complete '{name}' again")
                         loop.run_until_complete(future)
                         assert future.done()
                     # read potential exception to avoid asyncio error
                     _ = future.exception()  # noqa: F841
-                    logger.debug(
-                        "run_until_complete '{name}' finished"
-                        .format_map(locals()))
+                    logger.debug(f"run_until_complete '{name}' finished")
                     return signal.SIGINT
                 except Exception as e:  # noqa: F841
                     exc = traceback.format_exc()
                     logger.error(
-                        "Exception in job execution '{name}': {e}\n{exc}"
-                        .format_map(locals()))
+                        f"Exception in job execution '{name}': {e}\n{exc}")
                     return 1
                 result = future.result()
                 logger.debug(
-                    "run_until_complete '{name}' finished with '{result}'"
-                    .format_map(locals()))
+                    f"run_until_complete '{name}' finished with '{result}'")
                 if result:
                     if not rc:
                         rc = result
@@ -98,7 +90,7 @@ class SequentialExecutor(ExecutorExtensionPoint):
                 all_tasks = asyncio.Task.all_tasks
             for task in all_tasks(loop):
                 if not task.done():
-                    logger.error("Task '{task}' not done".format_map(locals()))
+                    logger.error(f"Task '{task}' not done")
             # HACK on Windows closing the event loop seems to hang after Ctrl-C
             # even though no futures are pending
             if sys.platform != 'win32':

--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -54,7 +54,7 @@ def set_default_config_path(*, path, env_var=None):
     _config_path = Path(str(path))
     _config_path_env_var = env_var
     config_path = get_config_path()
-    logger.info("Using config path '{config_path}'".format_map(locals()))
+    logger.info(f"Using config path '{config_path}'")
 
 
 def _reset_config_path_globals():
@@ -202,7 +202,7 @@ def create_log_path(verb_name):
             path = path_with_suffix
             break
 
-    logger.info("Using log path '{path}'".format_map(locals()))
+    logger.info(f"Using log path '{path}'")
 
     # ensure the base log path has an ignore marker file
     # to avoid recursively crawling through log directories
@@ -211,10 +211,9 @@ def create_log_path(verb_name):
     ignore_marker.touch()
 
     # create latest symlinks
+    _create_symlink(path, path.parent / f'latest_{verb_name}')
     _create_symlink(
-        path, path.parent / 'latest_{verb_name}'.format_map(locals()))
-    _create_symlink(
-        path.parent / 'latest_{verb_name}'.format_map(locals()),
+        path.parent / f'latest_{verb_name}',
         path.parent / 'latest')
 
 

--- a/colcon_core/logging.py
+++ b/colcon_core/logging.py
@@ -33,8 +33,8 @@ def set_logger_level_from_env(logger, env_name):
             numeric_log_level = get_numeric_log_level(log_level)
         except ValueError as e:  # noqa: F841
             logger.warning(
-                "environment variable '{env_name}' has unsupported value "
-                "'{log_level}', {e}".format_map(locals()))
+                f"environment variable '{env_name}' has unsupported value "
+                f"'{log_level}', {e}")
         else:
             logger.setLevel(numeric_log_level)
 

--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -103,8 +103,7 @@ def augment_packages(
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package augmentation extension '
-                "'{extension.PACKAGE_AUGMENTATION_NAME}': "
-                '{e}\n{exc}'.format_map(locals()))
+                f"'{extension.PACKAGE_AUGMENTATION_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 
@@ -143,7 +142,7 @@ def update_descriptor(
                 desc.dependencies[dep_type].add(d)
     # transfer type specific dependencies
     for dep_type in dep_types:
-        key = '{dep_type}-dependencies'.format_map(locals())
+        key = f'{dep_type}-dependencies'
         if key in data:
             for d in data[key]:
                 desc.dependencies[dep_type].add(d)
@@ -159,8 +158,7 @@ def update_descriptor(
         # skip any of the already explicitly handled names
         ignored_names = ['name', 'type', 'dependencies', 'hooks']
         for dep_type in dep_types:
-            ignored_names.append(
-                '{dep_type}-dependencies'.format_map(locals()))
+            ignored_names.append(f'{dep_type}-dependencies')
         for name in data.keys():
             if name in ignored_names:
                 continue
@@ -217,8 +215,8 @@ def update_metadata(desc, key, value):
 
     if type(old_value) != type(value):
         logger.warning(
-            "update package '{desc.name}' metadata '{key}' from value "
-            "'{old_value}' to '{value}'".format_map(locals()))
+            f"update package '{desc.name}' metadata '{key}' from value "
+            f"'{old_value}' to '{value}'")
 
     # overwrite existing value
     # copy value to avoid changes to either of them to affect each other

--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -126,8 +126,7 @@ def create_dependency_descriptor(requirement_string):
             metadata['version_lt'] = _next_incompatible_version(version)
         else:
             logger.warning(
-                "Ignoring unknown symbol '{symbol}' in '{requirement}'"
-                .format_map(locals()))
+                f"Ignoring unknown symbol '{symbol}' in '{requirement}'")
     return DependencyDescriptor(requirement.name, metadata=metadata)
 
 

--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -76,8 +76,7 @@ class PackageDescriptor:
         for category in sorted(categories):
             dependencies |= self.dependencies[category]
         assert self.name not in dependencies, \
-            "The package '{self.name}' has a dependency with the same name" \
-            .format_map(locals())
+            f"The package '{self.name}' has a dependency with the same name"
         return {
             (DependencyDescriptor(d)
                 if not isinstance(d, DependencyDescriptor) else d)

--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -121,8 +121,7 @@ def add_package_discovery_arguments(parser, *, extensions=None):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package discovery extension '
-                "'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
         else:
             if has_default:
@@ -141,8 +140,7 @@ def add_package_discovery_arguments(parser, *, extensions=None):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package discovery extension '
-                "'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 
@@ -222,9 +220,8 @@ def _get_extensions_with_parameters(
     with_parameters = OrderedDict()
     for extension in discovery_extensions.values():
         logger.log(
-            1,
-            'discover_packages({extension.PACKAGE_DISCOVERY_NAME}) check '
-            'parameters'.format_map(locals()))
+            1, f'discover_packages({extension.PACKAGE_DISCOVERY_NAME}) check '
+            'parameters')
         try:
             has_parameter = extension.has_parameters(args=args)
         except Exception as e:  # noqa: F841
@@ -232,8 +229,7 @@ def _get_extensions_with_parameters(
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package discovery extension '
-                "'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
         else:
             if has_parameter:
@@ -262,8 +258,7 @@ def _discover_packages(
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package discovery extension '
-                "'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
             continue
         else:

--- a/colcon_core/package_identification/__init__.py
+++ b/colcon_core/package_identification/__init__.py
@@ -114,8 +114,7 @@ def identify(
 
     if getattr(desc, 'type', None) or getattr(desc, 'name', None):
         logger.warning(
-            "package '{desc.path}' has type or name but is incomplete"
-            .format_map(locals()))
+            f"package '{desc.path}' has type or name but is incomplete")
     return None
 
 
@@ -150,8 +149,8 @@ def _identify(extensions_same_prio, desc):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package identification extension '
-                "'{extension.PACKAGE_IDENTIFICATION_NAME}' in '{desc.path}': "
-                '{e}\n{exc}'.format_map(locals()))
+                f"'{extension.PACKAGE_IDENTIFICATION_NAME}' in '{desc.path}': "
+                f'{e}\n{exc}')
             # skip failing extension, continue with next one
             continue
 
@@ -165,8 +164,8 @@ def _identify(extensions_same_prio, desc):
     # multiple extensions populated the descriptor with different values
     if len(results) > 2:
         logger.warning(
-            '_identify({desc.path}) has multiple matches and therefore is '
-            'being ignored: '.format_map(locals()) +
+            f'_identify({desc.path}) has multiple matches and therefore is '
+            'being ignored: ' +
             ', '.join(sorted(d.type for d in results if d.type is not None)))
         return False
 
@@ -177,8 +176,8 @@ def _identify(extensions_same_prio, desc):
     results.remove(desc)
     desc = results.pop()
     logger.debug(
-        "Package '{desc.path}' with type '{desc.type}' and name '{desc.name}'"
-        .format_map(locals()))
+        f"Package '{desc.path}' with type '{desc.type}' and name "
+        f"'{desc.name}'")
     return desc
 
 

--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -37,10 +37,9 @@ class PythonPackageIdentification(PackageIdentificationExtensionPoint):
 
         if not is_reading_cfg_sufficient(setup_py):
             logger.debug(
-                "Python package in '{desc.path}' passes arguments to the "
+                f"Python package in '{desc.path}' passes arguments to the "
                 'setup() function which requires a different identification '
-                "extension than '{self.PACKAGE_IDENTIFICATION_NAME}'"
-                .format_map(locals()))
+                f"extension than '{self.PACKAGE_IDENTIFICATION_NAME}'")
             return
 
         config = get_configuration(setup_cfg)
@@ -95,9 +94,9 @@ def get_configuration(setup_cfg):
         if parse_version(setuptools_version) < parse_version(minimum_version):
             e.msg += ', ' \
                 "'setuptools' needs to be at least version " \
-                '{minimum_version}, if a newer version is not available ' \
+                f'{minimum_version}, if a newer version is not available ' \
                 "from the package manager use 'pip3 install -U setuptools' " \
-                'to update to the latest version'.format_map(locals())
+                'to update to the latest version'
         raise
     return read_configuration(str(setup_cfg))
 

--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -116,8 +116,7 @@ def _add_package_selection_arguments(parser):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package selection extension '
-                "'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 
@@ -156,7 +155,7 @@ def get_packages(
     if len({d.name for d in pkgs}) < len(pkgs):
         pkg_paths = defaultdict(list)
         for d in pkgs:
-            pkg_paths[d.name].append('  - {d.path}'.format_map(locals()))
+            pkg_paths[d.name].append(f'  - {d.path}')
         raise RuntimeError(
             'Duplicate package names not supported:\n' +
             '\n'.join(
@@ -205,8 +204,7 @@ def _check_package_selection_parameters(args, pkg_names):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package selection extension '
-                "'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 
@@ -232,6 +230,5 @@ def select_package_decorators(args, decorators):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in package selection extension '
-                "'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}"
-                .format_map(locals()))
+                f"'{extension.PACKAGE_SELECTION_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one

--- a/colcon_core/plugin_system.py
+++ b/colcon_core/plugin_system.py
@@ -62,15 +62,14 @@ def _instantiate_extension(
             'invocation should return an object'
     except SkipExtensionException as e:  # noqa: F841
         logger.info(
-            "Skipping extension '{group_name}.{extension_name}': {e}"
-            .format_map(locals()))
+            f"Skipping extension '{group_name}.{extension_name}': {e}")
         extension_instance = None
     except Exception as e:  # noqa: F841
         # catch exceptions raised in extension constructor
         exc = traceback.format_exc()
         logger.error(
             'Exception instantiating extension '
-            "'{group_name}.{extension_name}': {e}\n{exc}".format_map(locals()))
+            f"'{group_name}.{extension_name}': {e}\n{exc}")
         extension_instance = None
     if not unique_instance:
         _extension_instances[extension_class] = extension_instance

--- a/colcon_core/prefix_path/__init__.py
+++ b/colcon_core/prefix_path/__init__.py
@@ -81,8 +81,7 @@ def get_chained_prefix_path(*, skip=None):
                 exc = traceback.format_exc()
                 logger.error(
                     'Exception in prefix path extension '
-                    "'{extension.PREFIX_PATH_NAME}': {e}\n{exc}"
-                    .format_map(locals()))
+                    f"'{extension.PREFIX_PATH_NAME}': {e}\n{exc}")
                 # skip failing extension, continue with next one
     unique_prefix_path = []
     for p in chained_prefix_path:

--- a/colcon_core/prefix_path/colcon.py
+++ b/colcon_core/prefix_path/colcon.py
@@ -29,9 +29,8 @@ class ColconPrefixPath(PrefixPathExtensionPoint):
             if not os.path.exists(path):
                 if path not in _get_colcon_prefix_path_warnings:
                     logger.warning(
-                        "The path '{path}' in the environment variable "
-                        "COLCON_PREFIX_PATH doesn't exist"
-                        .format_map(locals()))
+                        f"The path '{path}' in the environment variable "
+                        "COLCON_PREFIX_PATH doesn't exist")
                 _get_colcon_prefix_path_warnings.add(path)
                 continue
             paths.append(path)

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -300,13 +300,13 @@ async def get_command_environment(task_name, build_base, dependencies):
             except NotImplementedError:
                 # skip extension, continue with next one
                 logger.debug(
-                    "Skip shell extension '{extension.SHELL_NAME}' for "
-                    'command environment'.format_map(locals()))
+                    f"Skip shell extension '{extension.SHELL_NAME}' for "
+                    'command environment')
             except SkipExtensionException as e:  # noqa: F841
                 # skip extension, continue with next one
                 logger.info(
-                    "Skip shell extension '{extension.SHELL_NAME}' for "
-                    'command environment: {e}'.format_map(locals()))
+                    f"Skip shell extension '{extension.SHELL_NAME}' for "
+                    f'command environment: {e}')
             except (CancelledError, RuntimeError):
                 # re-raise same exception to handle it in the executor
                 # without a traceback
@@ -316,8 +316,7 @@ async def get_command_environment(task_name, build_base, dependencies):
                 exc = traceback.format_exc()
                 logger.error(
                     'Exception in shell extension '
-                    "'{extension.SHELL_NAME}': {e}\n{exc}"
-                    .format_map(locals()))
+                    f"'{extension.SHELL_NAME}': {e}\n{exc}")
                 # skip failing extension, continue with next one
     raise RuntimeError(
         'Could not find a shell extension for the command environment')
@@ -345,7 +344,7 @@ async def get_environment_variables(cmd, *, cwd=None, shell=True):
             line_replaced = line.decode(encoding=encoding, errors='replace')
             logger.warning(
                 'Failed to decode line from the environment using the '
-                "encoding '{encoding}': {line_replaced}".format_map(locals()))
+                f"encoding '{encoding}': {line_replaced}")
             continue
         parts = line.split('=', 1)
         if sys.platform != 'win32':
@@ -409,8 +408,7 @@ def create_environment_hook(
                     exc = traceback.format_exc()
                     logger.error(
                         'Exception in shell extension '
-                        "'{extension.SHELL_NAME}': {e}\n{exc}"
-                        .format_map(locals()))
+                        f"'{extension.SHELL_NAME}': {e}\n{exc}")
                     # skip failing extension, continue with next one
                     continue
                 hooks.append(hook)
@@ -428,8 +426,7 @@ def create_environment_hook(
                     exc = traceback.format_exc()
                     logger.error(
                         'Exception in shell extension '
-                        "'{extension.SHELL_NAME}': {e}\n{exc}"
-                        .format_map(locals()))
+                        f"'{extension.SHELL_NAME}': {e}\n{exc}")
                     # skip failing extension, continue with next one
                     continue
                 hooks.append(hook)
@@ -474,8 +471,8 @@ def get_colcon_prefix_path(*, skip=None):
         if not os.path.exists(path):
             if path not in _get_colcon_prefix_path_warnings:
                 logger.warning(
-                    "The path '{path}' in the environment variable "
-                    "COLCON_PREFIX_PATH doesn't exist".format_map(locals()))
+                    f"The path '{path}' in the environment variable "
+                    "COLCON_PREFIX_PATH doesn't exist")
             _get_colcon_prefix_path_warnings.add(path)
             continue
         prefix_path.append(path)
@@ -551,8 +548,7 @@ def find_installed_packages_in_environment():
         prefix_path = Path(prefix_path)
         pkgs = find_installed_packages(prefix_path)
         if pkgs is None:
-            logger.debug(
-                "Ignoring prefix path '{prefix_path}'".format_map(locals()))
+            logger.debug(f"Ignoring prefix path '{prefix_path}'")
             continue
         for pkg_name in sorted(pkgs.keys()):
             # ignore packages with the same name in "lower" prefix path
@@ -635,16 +631,16 @@ def find_installed_packages(install_base: Path):
         for pkg, path in ext_packages.items():
             if not path.exists():
                 logger.warning(
-                    "Ignoring '{pkg}' found at '{path}' because the path"
-                    ' does not exist.'.format_map(locals()))
+                    f"Ignoring '{pkg}' found at '{path}' because the path"
+                    ' does not exist.')
                 continue
             if pkg in packages and not path.samefile(packages[pkg]):
                 # Same package found at different paths in the same prefix
                 first_path = packages[pkg]
                 logger.warning(
-                    "The package '{pkg}' previously found at "
-                    "'{first_path}' was found again at '{path}'."
-                    " Ignoring '{path}'".format_map(locals()))
+                    f"The package '{pkg}' previously found at "
+                    f"'{first_path}' was found again at '{path}'."
+                    f" Ignoring '{path}'")
             else:
                 packages[pkg] = path
 

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -150,6 +150,6 @@ class BatShell(ShellExtensionPoint):
         with env_path.open('w') as h:
             for key in sorted(env.keys()):
                 value = env[key]
-                h.write('{key}={value}\n'.format_map(locals()))
+                h.write(f'{key}={value}\n')
 
         return env

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -151,6 +151,6 @@ class ShShell(ShellExtensionPoint):
         with env_path.open('w') as h:
             for key in sorted(env.keys()):
                 value = env[key]
-                h.write('{key}={value}\n'.format_map(locals()))
+                h.write(f'{key}={value}\n')
 
         return env

--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -43,8 +43,7 @@ def expand_template(template_path, destination_path, data):
         output = output.getvalue()
     except Exception as e:  # noqa: F841
         logger.error(
-            "{e.__class__.__name__} processing template '{template_path}'"
-            .format_map(locals()))
+            f"{e.__class__.__name__} processing template '{template_path}'")
         raise
     else:
         os.makedirs(str(destination_path.parent), exist_ok=True)

--- a/colcon_core/shell/template/prefix_util.py.em
+++ b/colcon_core/shell/template/prefix_util.py.em
@@ -302,8 +302,8 @@ def handle_dsv_types_except_source(type_, remainder, prefix):
                 type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and
                 not os.path.exists(value)
             ):
-                comment = 'skip extending {env_name} with not existing path: ' \
-                    '{value}'.format_map(locals())
+                comment = f'skip extending {env_name} with not existing ' \
+                    f'path: {value}'
                 if _include_comments():
                     commands.append(
                         FORMAT_STR_COMMENT_LINE.format_map({'comment': comment}))

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -104,8 +104,7 @@ async def check_output(
         **other_popen_kwargs)
     if rc:
         stderr_data = stderr_data.decode(errors='replace')
-    assert not rc, \
-        'Expected {args} to pass: {stderr_data}'.format_map(locals())
+    assert not rc, f'Expected {args} to pass: {stderr_data}'
     return stdout_data
 
 

--- a/colcon_core/task/__init__.py
+++ b/colcon_core/task/__init__.py
@@ -218,8 +218,7 @@ def add_task_arguments(parser, task_name):
     extensions = get_task_extensions(task_name, unique_instance=True)
     for extension_name, extension in extensions.items():
         group = parser.add_argument_group(
-            title="Arguments for '{extension_name}' packages"
-            .format_map(locals()))
+            title=f"Arguments for '{extension_name}' packages")
         try:
             retval = extension.add_arguments(parser=group)
             assert retval is None, 'add_arguments() should return None'
@@ -227,9 +226,8 @@ def add_task_arguments(parser, task_name):
             # catch exceptions raised in task extension
             exc = traceback.format_exc()
             logger.error(
-                'Exception in task extension '
-                "'{extension.TASK_NAME}.{extension.PACKAGE_TYPE}': {e}\n{exc}"
-                .format_map(locals()))
+                f"Exception in task extension '{extension.TASK_NAME}."
+                f"{extension.PACKAGE_TYPE}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 

--- a/colcon_core/task/python/__init__.py
+++ b/colcon_core/task/python/__init__.py
@@ -40,8 +40,7 @@ def get_data_files_mapping(data_files):
             assert isinstance(sources, list)
             for source in sources:
                 assert not os.path.isabs(source), \
-                    "'data_files' must be relative, '{source}' is absolute" \
-                    .format_map(locals())
+                    f"'data_files' must be relative, '{source}' is absolute"
                 mapping[source] = os.path.join(dest, os.path.basename(source))
         else:
             assert not os.path.isabs(data_file)

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -40,8 +40,7 @@ class PythonBuildTask(TaskExtensionPoint):
         pkg = self.context.pkg
         args = self.context.args
 
-        logger.info(
-            "Building Python package in '{args.path}'".format_map(locals()))
+        logger.info(f"Building Python package in '{args.path}'")
 
         try:
             env = await get_command_environment(
@@ -189,9 +188,8 @@ class PythonBuildTask(TaskExtensionPoint):
         for module_name in packages:
             if module_name in sys.modules:
                 logger.warning(
-                    "Switching to 'develop' for package '{pkg.name}' while it "
-                    'is being used might result in import errors later'
-                    .format_map(locals()))
+                    f"Switching to 'develop' for package '{pkg.name}' while "
+                    'it is being used might result in import errors later')
                 break
 
         # remove previously installed files
@@ -203,8 +201,7 @@ class PythonBuildTask(TaskExtensionPoint):
             if not line.startswith(python_lib):
                 logger.debug(
                     'While undoing a previous installation files outside the '
-                    'Python library path are being ignored: {line}'
-                    .format_map(locals()))
+                    f'Python library path are being ignored: {line}')
                 continue
             if not os.path.isdir(line):
                 os.remove(line)
@@ -238,21 +235,19 @@ class PythonBuildTask(TaskExtensionPoint):
                 if package_dir[package] in package_dir:
                     package_dir_package = package_dir[package]
                     raise RuntimeError(
-                        "The package_dir contains a mapping from '{package}' "
-                        "to '{package_dir_package}' which is also a key"
-                        .format_map(locals()))
+                        f"The package_dir contains a mapping from '{package}' "
+                        f"to '{package_dir_package}' which is also a key")
                 if package_dir[package] in packages:
                     package_dir_package = package_dir[package]
                     raise RuntimeError(
-                        "The value '{package_dir_package}' in package_dir is "
-                        'also listed in packages'
-                        .format_map(locals()))
+                        f"The value '{package_dir_package}' in package_dir is "
+                        'also listed in packages')
             elif '' in package_dir:
                 items.append(os.path.join(package_dir[''], package))
             else:
                 items.append(package)
         # relative python-ish paths are allowed as entries in py_modules, see:
-        # https://docs.python.org/3.5/distutils/setupscript.html#listing-individual-modules
+        # https://docs.python.org/3.6/distutils/setupscript.html#listing-individual-modules
         py_modules = setup_py_data.get('py_modules')
         if py_modules:
             py_modules_list = [
@@ -260,8 +255,7 @@ class PythonBuildTask(TaskExtensionPoint):
             for py_module in py_modules_list:
                 if not os.path.exists(os.path.join(args.path, py_module)):
                     raise RuntimeError(
-                        "Provided py_modules '{py_module}' does not exist"
-                        .format_map(locals()))
+                        f"Provided py_modules '{py_module}' does not exist")
             items += py_modules_list
         data_files = get_data_files_mapping(
             setup_py_data.get('data_files') or [])

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -29,11 +29,9 @@ class PythonTestTask(TaskExtensionPoint):
         add_python_testing_step_arguments(parser)
 
     async def test(self, *, additional_hooks=None):  # noqa: D102
-        pkg = self.context.pkg
         args = self.context.args
 
-        logger.info(
-            "Testing Python package in '{args.path}'".format_map(locals()))
+        logger.info(f"Testing Python package in '{args.path}'")
 
         try:
             env = await get_command_environment(
@@ -49,14 +47,12 @@ class PythonTestTask(TaskExtensionPoint):
             extension = get_python_testing_step_extension(key)
             if extension is None:
                 logger.error(
-                    "Failed to load Python testing step extension '{key}'"
-                    .format_map(locals()))
+                    f"Failed to load Python testing step extension '{key}'")
                 return 1
         else:
             extensions = get_python_testing_step_extensions()
             for key, extension in extensions.items():
-                logger.log(
-                    1, "test() by extension '{key}'".format_map(locals()))
+                logger.log(1, f"test() by extension '{key}'")
                 try:
                     matched = extension.match(self.context, env, setup_py_data)
                 except Exception as e:  # noqa: F841
@@ -64,20 +60,18 @@ class PythonTestTask(TaskExtensionPoint):
                     exc = traceback.format_exc()
                     logger.error(
                         'Exception in Python testing step extension '
-                        "'{extension.STEP_TYPE}': {e}\n{exc}"
-                        .format_map(locals()))
+                        f"'{extension.STEP_TYPE}': {e}\n{exc}")
                     # skip failing extension, continue with next one
                     continue
                 if matched:
                     break
             else:
                 logger.warning(
-                    "No Python Testing Step extension matched in '{args.path}'"
-                    .format_map(locals()))
+                    'No Python Testing Step extension matched in '
+                    f"'{args.path}'")
                 return
 
-        logger.log(
-            1, "test.step() by extension '{key}'".format_map(locals()))
+        logger.log(1, f"test.step() by extension '{key}'")
         try:
             return await extension.step(self.context, env, setup_py_data)
         except Exception as e:  # noqa: F841
@@ -85,7 +79,7 @@ class PythonTestTask(TaskExtensionPoint):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in Python testing step extension '
-                "'{extension.STEP_TYPE}': {e}\n{exc}".format_map(locals()))
+                f"'{extension.STEP_TYPE}': {e}\n{exc}")
             return 1
 
 
@@ -171,13 +165,13 @@ def add_python_testing_step_arguments(parser):
             # to mention the available options
             desc = '<no description>'
         # it requires a custom formatter to maintain the newline
-        descriptions += '\n* {key}: {desc}'.format_map(locals())
+        descriptions += f'\n* {key}: {desc}'
 
     parser.add_argument(
         '--python-testing', type=str, choices=sorted(extensions.keys()),
         help='The Python testing framework to use (default: determined '
              'based on the packages `tests_require`)'
-             '{descriptions}'.format_map(locals()))
+             f'{descriptions}')
 
     for extension in extensions.values():
         try:
@@ -188,7 +182,7 @@ def add_python_testing_step_arguments(parser):
             exc = traceback.format_exc()
             logger.error(
                 'Exception in Python testing step extension '
-                "'{extension.STEP_TYPE}': {e}\n{exc}".format_map(locals()))
+                f"'{extension.STEP_TYPE}': {e}\n{exc}")
             # skip failing extension, continue with next one
 
 

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -80,8 +80,8 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             except ImportError:
                 logger.warning(
                     'Test coverage will not be produced for package '
-                    "'{context.pkg.name}' since the pytest extension 'cov' "
-                    'was not found'.format_map(locals()))
+                    f"'{context.pkg.name}' since the pytest extension 'cov' "
+                    'was not found')
             else:
                 args += [
                     '--cov=' + str(PurePosixPath(
@@ -104,7 +104,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                         'Test coverage will be produced but will not contain '
                         'branch coverage information because the pytest '
                         "extension 'cov' does not support it (need 2.5.0, "
-                        'have {pytest_cov_version})'.format_map(locals()))
+                        f'have {pytest_cov_version})')
                 env['COVERAGE_FILE'] = os.path.join(
                     context.args.build_base, '.coverage')
 
@@ -114,13 +114,11 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             except ImportError:
                 logger.warning(
                     "Ignored '--retest-until-fail' for package "
-                    "'{context.pkg.name}' since the pytest extension 'repeat' "
-                    'was not found'.format_map(locals()))
+                    f"'{context.pkg.name}' since the pytest extension "
+                    "'repeat' was not found")
             else:
                 count = context.args.retest_until_fail + 1
-                args += [
-                    '--count={count}'.format_map(locals()),
-                ]
+                args += [f'--count={count}']
 
         if context.args.retest_until_pass:
             try:
@@ -128,32 +126,29 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             except ImportError:
                 logger.warning(
                     "Ignored '--retest-until-pass' for package "
-                    "'{context.pkg.name}' since pytest extension "
-                    "'rerunfailures' was not found".format_map(locals()))
+                    f"'{context.pkg.name}' since pytest extension "
+                    "'rerunfailures' was not found")
             else:
-                args += [
-                    '--reruns={context.args.retest_until_pass}'
-                    .format_map(locals()),
-                ]
+                args += [f'--reruns={context.args.retest_until_pass}']
 
         if context.args.pytest_args is not None:
             args += context.args.pytest_args
 
         if args:
             env['PYTEST_ADDOPTS'] = ' '.join(
-                a if ' ' not in a else '"{a}"'.format_map(locals())
+                a if ' ' not in a else f'"{a}"'
                 for a in args)
 
         # create dummy result in case the invocation fails early
         # and doesn't generate a result file at all
         junit_xml_path.parent.mkdir(parents=True, exist_ok=True)
-        junit_xml_path.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+        junit_xml_path.write_text(f"""<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="{context.pkg.name}" tests="1" failures="0" time="0" errors="1" skipped="0">
   <testcase classname="{context.pkg.name}" name="pytest.missing_result" time="0">
     <failure message="The test invocation failed without generating a result file."/>
   </testcase>
 </testsuite>
-""".format_map(locals()))  # noqa: E501
+""")  # noqa: E501
 
         completed = await run(
             context, cmd, cwd=context.args.path, env=env)

--- a/colcon_core/task/python/test/setuppy_test.py
+++ b/colcon_core/task/python/test/setuppy_test.py
@@ -33,14 +33,14 @@ class SetuppyPythonTestingStep(PythonTestingStepExtensionPoint):
         if context.args.retest_until_fail:
             logger.warning(
                 "Ignored '--retest-until-fail' for package "
-                "'{context.pkg.name}' since 'unittest' does not support the "
-                'usage'.format_map(locals()))
+                f"'{context.pkg.name}' since 'unittest' does not support the "
+                'usage')
 
         if context.args.retest_until_pass:
             logger.warning(
                 "Ignored '--retest-until-pass' for package "
-                "'{context.pkg.name}' since 'unittest' does not support the "
-                'usage'.format_map(locals()))
+                f"'{context.pkg.name}' since 'unittest' does not support the "
+                'usage')
 
         cmd = [executable, '-m', 'unittest', '-v']
         if context.args.unittest_args is not None:

--- a/colcon_core/verb/__init__.py
+++ b/colcon_core/verb/__init__.py
@@ -80,9 +80,9 @@ def check_and_mark_build_tool(build_base, *, this_build_tool='colcon'):
             if previous_build_tool == this_build_tool:
                 return
             raise RuntimeError(
-                "The build directory '{build_base}' was created by "
-                "'{previous_build_tool}'. Please remove the build directory "
-                'or pick a different one.'.format_map(locals()))
+                f"The build directory '{build_base}' was created by "
+                f"'{previous_build_tool}'. Please remove the build directory "
+                'or pick a different one.')
     else:
         os.makedirs(build_base, exist_ok=True)
 
@@ -109,17 +109,16 @@ def check_and_mark_install_layout(install_base, *, merge_install):
                 return
             change_option = 'remove' if merge_install else 'add'
             raise RuntimeError(
-                "The install directory '{install_base}' was created with the "
-                "layout '{previous_install_layout}'. Please remove the "
-                'install directory, pick a different one or {change_option} '
-                "the '--merge-install' option.".format_map(locals()))
+                f"The install directory '{install_base}' was created with the "
+                f"layout '{previous_install_layout}'. Please remove the "
+                f'install directory, pick a different one or {change_option} '
+                "the '--merge-install' option.")
     else:
         try:
             os.makedirs(install_base, exist_ok=True)
         except FileExistsError:
             raise RuntimeError(
-                "The install base '{install_base}' is not a directory"
-                .format_map(locals()))
+                f"The install base '{install_base}' is not a directory")
 
     marker_path.write_text(this_install_layout + '\n')
 
@@ -150,8 +149,8 @@ def update_object(
     """
     if not hasattr(object_, key):
         logger.log(
-            5, "set package '{package_name}' {argument_type} argument '{key}' "
-            "from {value_source} to '{value}'".format_map(locals()))
+            5, f"set package '{package_name}' {argument_type} argument "
+            f"'{key}' from {value_source} to '{value}'")
         # add value to the object
         # copy value to avoid changes to either of them to affect each other
         setattr(object_, key, copy.deepcopy(value))
@@ -160,16 +159,16 @@ def update_object(
     old_value = getattr(object_, key)
     if isinstance(old_value, dict) and isinstance(value, dict):
         logger.log(
-            5, "update package '{package_name}' {argument_type} argument "
-            "'{key}' from {value_source} with '{value}'".format_map(locals()))
+            5, f"update package '{package_name}' {argument_type} argument "
+            f"'{key}' from {value_source} with '{value}'")
         # update dictionary
         old_value.update(value)
         return
 
     if isinstance(old_value, list) and isinstance(value, list):
         logger.log(
-            5, "extend package '{package_name}' {argument_type} argument "
-            "'{key}' from {value_source} with '{value}'".format_map(locals()))
+            5, f"extend package '{package_name}' {argument_type} argument "
+            f"'{key}' from {value_source} with '{value}'")
         # extend list
         old_value += value
         return
@@ -178,9 +177,9 @@ def update_object(
         if old_value is None or type(old_value) == type(value) \
         else logging.WARNING
     logger.log(
-        severity, "overwrite package '{package_name}' {argument_type} "
-        "argument '{key}' from {value_source} with '{value}' (before: "
-        "'{old_value}')".format_map(locals()))
+        severity, f"overwrite package '{package_name}' {argument_type} "
+        f"argument '{key}' from {value_source} with '{value}' (before: "
+        f"'{old_value}')")
     # overwrite existing value
     # copy value to avoid changes to either of them to affect each other
     setattr(object_, key, copy.deepcopy(value))

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -174,8 +174,7 @@ class BuildVerb(VerbExtensionPoint):
             if overlay_package in underlay_packages:
                 if overlay_package not in context.args.allow_overriding:
                     override_messages[overlay_package] = (
-                        "'{overlay_package}'".format_map(locals()) +
-                        ' is in: ' +
+                        f"'{overlay_package}' is in: " +
                         ', '.join(underlay_packages[overlay_package]))
 
         if override_messages:
@@ -247,8 +246,7 @@ class BuildVerb(VerbExtensionPoint):
             extension = get_task_extension('colcon_core.task.build', pkg.type)
             if not extension:
                 logger.warning(
-                    "No task extension to 'build' a '{pkg.type}' package"
-                    .format_map(locals()))
+                    f"No task extension to 'build' a '{pkg.type}' package")
                 continue
 
             recursive_dependencies = OrderedDict()
@@ -266,8 +264,8 @@ class BuildVerb(VerbExtensionPoint):
                 for k in sorted(package_args.__dict__.keys())
             ])
             logger.debug(
-                "Building package '{pkg.name}' with the following arguments: "
-                '{{{ordered_package_args}}}'.format_map(locals()))
+                f"Building package '{pkg.name}' with the following arguments: "
+                f'{{{ordered_package_args}}}')
             task_context = TaskContext(
                 pkg=pkg, args=package_args,
                 dependencies=recursive_dependencies)
@@ -295,6 +293,5 @@ class BuildVerb(VerbExtensionPoint):
                     exc = traceback.format_exc()
                     logger.error(
                         'Exception in shell extension '
-                        "'{extension.SHELL_NAME}': {e}\n{exc}"
-                        .format_map(locals()))
+                        f"'{extension.SHELL_NAME}': {e}\n{exc}")
                     # skip failing extension, continue with next one

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -184,8 +184,7 @@ class TestVerb(VerbExtensionPoint):
             extension = get_task_extension('colcon_core.task.test', pkg.type)
             if not extension:
                 logger.warning(
-                    "No task extension to 'test' a '{pkg.type}' package"
-                    .format_map(locals()))
+                    f"No task extension to 'test' a '{pkg.type}' package")
                 continue
 
             recursive_dependencies = OrderedDict()
@@ -204,8 +203,8 @@ class TestVerb(VerbExtensionPoint):
                 for k in sorted(package_args.__dict__.keys())
             ])
             logger.debug(
-                "Testing package '{pkg.name}' with the following arguments: "
-                '{{{ordered_package_args}}}'.format_map(locals()))
+                f"Testing package '{pkg.name}' with the following arguments: "
+                f'{{{ordered_package_args}}}')
             task_context = TaskContext(
                 pkg=pkg, args=package_args,
                 dependencies=recursive_dependencies)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ long_description = file: README.rst
 keywords = colcon
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
   coloredlogs; sys_platform == 'win32'
   distlib

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 from pkg_resources import parse_version
 from setuptools import setup
 
-minimum_version = '3.5'
+minimum_version = '3.6'
 if (
     parse_version('%d.%d' % (sys.version_info.major, sys.version_info.minor)) <
     parse_version(minimum_version)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,4 +2,4 @@
 No-Python2:
 Depends3: python3-distlib, python3-empy, python3-pytest, python3-pytest-cov, python3-setuptools
 Suite: bionic focal jammy stretch buster bullseye
-X-Python3-Version: >= 3.5
+X-Python3-Version: >= 3.6

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -28,8 +28,8 @@ class Extension1(EnvironmentExtensionPoint):
 
     def create_environment_hooks(self, prefix_path, pkg_name):
         return [
-            '{prefix_path}/share/{pkg_name}/hook/one.ext'.format_map(locals()),
-            '{prefix_path}/share/{pkg_name}/hook/two.ext'.format_map(locals()),
+            f'{prefix_path}/share/{pkg_name}/hook/one.ext',
+            f'{prefix_path}/share/{pkg_name}/hook/two.ext',
         ]
 
 
@@ -105,10 +105,8 @@ def test_create_environment_hooks():
             with patch('colcon_core.environment.logger.error') as error:
                 hooks = create_environment_hooks(basepath, 'pkg_name')
     assert len(hooks) == 2
-    assert hooks[0] == '{basepath}/share/pkg_name/hook/one.ext' \
-        .format_map(locals())
-    assert hooks[1] == '{basepath}/share/pkg_name/hook/two.ext' \
-        .format_map(locals())
+    assert hooks[0] == f'{basepath}/share/pkg_name/hook/one.ext'
+    assert hooks[1] == f'{basepath}/share/pkg_name/hook/two.ext'
     # the raised exception is catched and results in an error message
     assert error.call_count == 1
     assert len(error.call_args[0]) == 1

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -49,9 +49,6 @@ def test_flake8():
         if report_tests.total_errors:
             report_tests._application.formatter.show_statistics(
                 report_tests._stats)
-        print(
-            'flake8 reported {total_errors} errors'
-            .format_map(locals()), file=sys.stderr)
+        print(f'flake8 reported {total_errors} errors', file=sys.stderr)
 
-    assert not total_errors, \
-        'flake8 reported {total_errors} errors'.format_map(locals())
+    assert not total_errors, f'flake8 reported {total_errors} errors'

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -36,16 +36,14 @@ def test_config_path():
     config_path = '/some/path'.replace('/', os.sep)
     with patch('colcon_core.location.logger.info') as info:
         set_default_config_path(path=config_path)
-        info.assert_called_once_with(
-            "Using config path '{config_path}'".format_map(locals()))
+        info.assert_called_once_with(f"Using config path '{config_path}'")
 
     # use config path if environment variable is not set
     config_path_env_var = 'TEST_COLCON_CONFIG_PATH'
     with patch('colcon_core.location.logger.info') as info:
         set_default_config_path(
             path=config_path, env_var=config_path_env_var)
-        info.assert_called_once_with(
-            "Using config path '{config_path}'".format_map(locals()))
+        info.assert_called_once_with(f"Using config path '{config_path}'")
 
     # use environment variable when set
     config_path = '/other/path'.replace('/', os.sep)

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -459,5 +459,5 @@ def test_find_package_two_locations():
                 assert {'pkgA': location1} == find_installed_packages(base)
                 mock_warn.assert_called_once_with(
                     "The package 'pkgA' previously found at"
-                    " '{location1}' was found again at '{location2}'."
-                    " Ignoring '{location2}'".format_map(locals()))
+                    f" '{location1}' was found again at '{location2}'."
+                    f" Ignoring '{location2}'")

--- a/test/test_shell_bat.py
+++ b/test/test_shell_bat.py
@@ -81,9 +81,9 @@ def _test_extension(prefix_path):
             run_until_complete(coroutine)
         assert str(e.value) == (
             'Failed to find the following files:\n'
-            '- {prefix_path}\\share\\dep\\package.bat\n'
+            f'- {prefix_path}\\share\\dep\\package.bat\n'
             'Check that the following packages have been built:\n'
-            '- dep'.format_map(locals()))
+            '- dep')
 
         # dependency script exists
         dep_script = prefix_path / 'share' / 'dep' / 'package.bat'

--- a/test/test_shell_sh.py
+++ b/test/test_shell_sh.py
@@ -82,9 +82,9 @@ def _test_extension(prefix_path):
             run_until_complete(coroutine)
         assert str(e.value) == (
             'Failed to find the following files:\n'
-            '- {prefix_path}/share/dep/package.sh\n'
+            f'- {prefix_path}/share/dep/package.sh\n'
             'Check that the following packages have been built:\n'
-            '- dep'.format_map(locals()))
+            '- dep')
 
         # dependency script exists
         dep_script = prefix_path / 'share' / 'dep' / 'package.sh'

--- a/test/test_shell_template.py
+++ b/test/test_shell_template.py
@@ -26,7 +26,7 @@ def test_expand_template():
         assert error.call_count == 1
         assert len(error.call_args[0]) == 1
         assert error.call_args[0][0].endswith(
-            " processing template '{template_path}'".format_map(locals()))
+            f" processing template '{template_path}'")
         assert not destination_path.exists()
 
         # missing variable
@@ -39,7 +39,7 @@ def test_expand_template():
         assert error.call_count == 1
         assert len(error.call_args[0]) == 1
         assert error.call_args[0][0].endswith(
-            " processing template '{template_path}'".format_map(locals()))
+            f" processing template '{template_path}'")
         assert not destination_path.exists()
 
         # skip all symlink tests on Windows for now

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -36,14 +36,14 @@ def test_spell_check(known_words):
 
     unknown_word_count = len(report.unknown_words)
     assert unknown_word_count == 0, \
-        'Found {unknown_word_count} unknown words: '.format_map(locals()) + \
+        f'Found {unknown_word_count} unknown words: ' + \
         ', '.join(sorted(report.unknown_words))
 
     unused_known_words = set(known_words) - report.found_known_words
     unused_known_word_count = len(unused_known_words)
     assert unused_known_word_count == 0, \
-        '{unused_known_word_count} words in the word list are not used: ' \
-        .format_map(locals()) + ', '.join(sorted(unused_known_words))
+        f'{unused_known_word_count} words in the word list are not used: ' + \
+        ', '.join(sorted(unused_known_words))
 
 
 def test_spell_check_word_list_order(known_words):


### PR DESCRIPTION
I only updated obvious uses of `format_map(locals())` to use f-strings. There are probably other strings which can now be simplified, but I'm considering them out-of-scope for this initial PR, which is big enough already.

Part of colcon/colcon-core#419