### PR TITLE
Use sysconfig directly to determine python lib dir

### DIFF
--- a/colcon_core/environment/pythonpath.py
+++ b/colcon_core/environment/pythonpath.py
@@ -1,13 +1,8 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from contextlib import suppress
-with suppress(ImportError):
-    # needed before importing distutils
-    # to avoid warning introduced in setuptools 49.2.0
-    import setuptools  # noqa: F401
-from distutils.sysconfig import get_python_lib
 from pathlib import Path
+import sysconfig
 
 from colcon_core import shell
 from colcon_core.environment import EnvironmentExtensionPoint
@@ -26,7 +21,8 @@ class PythonPathEnvironment(EnvironmentExtensionPoint):
     def create_environment_hooks(self, prefix_path, pkg_name):  # noqa: D102
         hooks = []
 
-        python_path = Path(get_python_lib(prefix=str(prefix_path)))
+        python_path = Path(
+            sysconfig.get_path('purelib', vars={'base': prefix_path}))
         logger.log(1, "checking '%s'" % python_path)
         if python_path.exists():
             rel_python_path = python_path.relative_to(prefix_path)

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -2,17 +2,13 @@
 # Licensed under the Apache License, Version 2.0
 
 from contextlib import suppress
-with suppress(ImportError):
-    # needed before importing distutils
-    # to avoid warning introduced in setuptools 49.2.0
-    import setuptools  # noqa: F401
-from distutils.sysconfig import get_python_lib
 import locale
 import os
 from pathlib import Path
 import shutil
 import sys
 from sys import executable
+import sysconfig
 
 from colcon_core.environment import create_environment_hooks
 from colcon_core.environment import create_environment_scripts
@@ -306,7 +302,7 @@ class PythonBuildTask(TaskExtensionPoint):
         return temp_symlinks
 
     def _get_python_lib(self, args):
-        path = get_python_lib(prefix=args.install_base)
+        path = sysconfig.get_path('purelib', vars={'base': args.install_base})
         return os.path.relpath(path, start=args.install_base)
 
     def _append_install_layout(self, args, cmd):

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -67,6 +67,7 @@ prepend
 prepended
 prepending
 proactor
+purelib
 pydocstyle
 pytest
 pytests

--- a/test/test_environment_pythonpath.py
+++ b/test/test_environment_pythonpath.py
@@ -1,8 +1,8 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from distutils.sysconfig import get_python_lib
 from pathlib import Path
+import sysconfig
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -23,7 +23,8 @@ def test_pythonpath():
             assert len(hooks) == 0
 
             # Python path exists
-            python_path = Path(get_python_lib(prefix=str(prefix_path)))
+            python_path = Path(
+                sysconfig.get_path('purelib', vars={'base': prefix_path}))
             python_path.mkdir(parents=True)
             hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
             assert len(hooks) == 2


### PR DESCRIPTION
The distutils package is deprecated and will be removed in Python 3.12. We can achieve the same behavior using sysconfig directly.