### PR TITLE
Make output of colcon colorful using colorama

### DIFF
--- a/colcon_core/event_handler/console_start_end.py
+++ b/colcon_core/event_handler/console_start_end.py
@@ -4,6 +4,8 @@
 import sys
 import time
 
+import colorama
+
 from colcon_core.event.job import JobEnded
 from colcon_core.event.job import JobStarted
 from colcon_core.event.test import TestFailure
@@ -25,6 +27,7 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
+        colorama.init()
         satisfies_version(
             EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
         self._start_times = {}
@@ -35,7 +38,10 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
 
         if isinstance(data, JobStarted):
             self._start_times[data.identifier] = time.monotonic()
-            print(f'Starting >>> {data.identifier}', flush=True)
+            msg = ('Starting ' + colorama.Fore.GREEN +
+                   colorama.Style.BRIGHT + '>>>' + colorama.Fore.CYAN +
+                   f' {data.identifier}' + colorama.Style.RESET_ALL)
+            print(msg, flush=True)
 
         elif isinstance(data, TestFailure):
             job = event[1]
@@ -46,19 +52,30 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
                 time.monotonic() - self._start_times[data.identifier]
             duration_string = format_duration(duration)
             if not data.rc:
-                msg = f'Finished <<< {data.identifier} [{duration_string}]'
+                msg = (colorama.Style.BRIGHT + colorama.Fore.BLACK +
+                       'Finished ' + colorama.Fore.GREEN + '<<<'
+                       + colorama.Style.RESET_ALL + colorama.Fore.CYAN
+                       + f' {data.identifier}' + colorama.Fore.RESET
+                       + ' [' + colorama.Fore.YELLOW +
+                       f'{duration_string}' + colorama.Fore.RESET + ']')
                 job = event[1]
                 if job in self._with_test_failures:
                     msg += '\t[ with test failures ]'
                 writable = sys.stdout
 
             elif data.rc == SIGINT_RESULT:
-                msg = f'Aborted  <<< {data.identifier} [{duration_string}]'
+                msg = (colorama.Style.BRIGHT + colorama.Fore.RED +
+                       'Aborted  ' + colorama.Style.NORMAL + '<<<'
+                       + colorama.Fore.CYAN + f' {data.identifier}'
+                       + colorama.Fore.RESET)
                 writable = sys.stdout
-
             else:
-                msg = f'Failed   <<< {data.identifier} ' \
-                    f'[{duration_string}, exited with code {data.rc}]'
+                msg = (colorama.Style.BRIGHT + colorama.Fore.RED +
+                       'Failed   ' + colorama.Style.NORMAL + '<<<' +
+                       colorama.Fore.CYAN + f' {data.identifier}' +
+                       colorama.Fore.RESET + ' [' + colorama.Fore.RED +
+                       f'Exited with code {data.rc}' +
+                       colorama.Fore.RESET + ']')
                 writable = sys.stderr
 
             print(msg, file=writable, flush=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords = colcon
 [options]
 python_requires = >=3.6
 install_requires =
+  colorama
   coloredlogs; sys_platform == 'win32'
   distlib
   EmPy<4

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-core]
 No-Python2:
-Depends3: python3-distlib, python3-empy (<4), python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata
+Depends3: python3-colorama, python3-distlib, python3-empy (<4), python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata
 Recommends3: python3-pytest-cov
 Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
 Replaces3: colcon


### PR DESCRIPTION
This pull request replaces #195. In general, it provides the same coloring, heavily inspired by catkin_tools. To do the formatting, it uses colorama, a library that also supports Windows. 