### PR TITLE
Improve handling of a broken stdout pipe

### DIFF
--- a/colcon_core/event_handler/console_start_end.py
+++ b/colcon_core/event_handler/console_start_end.py
@@ -34,10 +34,10 @@ class ConsoleStartEndEventHandler(EventHandlerExtensionPoint):
         data = event[0]
 
         if isinstance(data, JobStarted):
+            self._start_times[data.identifier] = time.monotonic()
             print(
                 'Starting >>> {data.identifier}'.format_map(locals()),
                 flush=True)
-            self._start_times[data.identifier] = time.monotonic()
 
         elif isinstance(data, TestFailure):
             job = event[1]


### PR DESCRIPTION
This doesn't cover all of the errors that can occur when `stdout` is closed, but it does improve the situation substantially.

My motivation for this change was a misconfigured invocation in which I was piping `stdout` from colcon to a dead process while `console_direct` was enabled. The console buffer was completely filled up with errors printed to `stderr` about the broken pipe to `stdout`, and I couldn't get far enough back to find the actual root cause of the problem.

When `stdout` or `stderr` are closed, we should stop trying to write to them.