### PR TITLE
Make pytest plugins 'Recommended' in debian package

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,6 @@
 [colcon-core]
 No-Python2:
-Depends3: python3-distlib, python3-empy, python3-pytest, python3-pytest-cov, python3-setuptools
+Depends3: python3-distlib, python3-empy, python3-pytest, python3-setuptools
+Recommends3: python3-pytest-cov, python3-pytest-repeat, python3-pytest-rerunfailures
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
The retest and rerunfilures packages are new to Ubuntu. All three of these pytest plugins are 'soft' dependencies. The code will gracefully handle their absence.

https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends
https://github.com/astraw/stdeb#stdebcfg-configuration-file

https://packages.ubuntu.com/search?keywords=python3-pytest-cov&searchon=names&suite=all&section=all
https://packages.ubuntu.com/search?keywords=python3-pytest-repeat&searchon=names&suite=all&section=all
https://packages.ubuntu.com/search?keywords=python3-pytest-rerunfailures&searchon=names&suite=all&section=all