### PR TITLE
Capture stdout and stderr

### DIFF
--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -72,12 +72,14 @@ async def run(
     assert callable(stderr_callback) or stderr_callback is None
 
     stdout_capture = []
+
     def _stdout_callback(line):
         if stdout_callback:
             stdout_callback(line)
         stdout_capture.append(line)
 
     stderr_capture = []
+
     def _stderr_callback(line):
         if stderr_callback:
             stderr_callback(line)

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -48,6 +48,7 @@ async def run(
     stderr_callback: Callable[[bytes], None],
     *,
     use_pty: Optional[bool] = None,
+    capture_output: Optional[bool] = None,
     **other_popen_kwargs: Mapping[str, Any]
 ) -> subprocess.CompletedProcess:
     """
@@ -65,6 +66,7 @@ async def run(
     :param stderr_callback: the callable is invoked for every line read from
       the stderr pipe of the process
     :param use_pty: whether to use a pseudo terminal
+    :param capture_output: whether to store stdout and stderr
     :returns: the result of the completed process
     :rtype subprocess.CompletedProcess
     """
@@ -76,14 +78,16 @@ async def run(
     def _stdout_callback(line):
         if stdout_callback:
             stdout_callback(line)
-        stdout_capture.append(line)
+        if capture_output:
+            stdout_capture.append(line)
 
     stderr_capture = []
 
     def _stderr_callback(line):
         if stderr_callback:
             stderr_callback(line)
-        stderr_capture.append(line)
+        if capture_output:
+            stderr_capture.append(line)
 
     # if use_pty is neither True nor False choose based on isatty of stdout
     if use_pty is None:

--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -94,11 +94,9 @@ async def run(
         args, _stdout_callback, _stderr_callback,
         use_pty=use_pty, **other_popen_kwargs)
 
-    completed = subprocess.CompletedProcess(args, rc)
-    completed.stdout = b''.join(stdout_capture)
-    completed.stderr = b''.join(stderr_capture)
-
-    return completed
+    return subprocess.CompletedProcess(
+        args, rc, stdout=b''.join(stdout_capture),
+        stderr=b''.join(stderr_capture))
 
 
 async def check_output(

--- a/colcon_core/task/__init__.py
+++ b/colcon_core/task/__init__.py
@@ -148,7 +148,8 @@ async def check_call(
 
 
 async def run(
-    context, cmd, *, cwd=None, env=None, shell=False, use_pty=None
+    context, cmd, *, cwd=None, env=None, shell=False, use_pty=None,
+    capture_output=None
 ):
     """
     Run the command described by cmd.
@@ -163,6 +164,7 @@ async def run(
     :param env: a dictionary with environment variables
     :param shell: whether to use the shell as the program to execute
     :param use_pty: whether to use a pseudo terminal
+    :param capture_output: whether to store stdout and stderr
     :returns: the result of the completed process
     :rtype subprocess.CompletedProcess
     """
@@ -176,7 +178,8 @@ async def run(
         Command(cmd, cwd=cwd, env=env, shell=shell))
     completed = await colcon_core_subprocess_run(
         cmd, stdout_callback, stderr_callback,
-        cwd=cwd, env=env, shell=shell, use_pty=use_pty)
+        cwd=cwd, env=env, shell=shell, use_pty=use_pty,
+        capture_output=capture_output)
     context.put_event_into_queue(
         CommandEnded(
             cmd, cwd=cwd, env=env, shell=shell,


### PR DESCRIPTION
This PR adds the output of running a process to the `stdout` and `stderr` fields of the returned [subprocess.CompletedProcess](https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess).

The rationale for this change is that because when running some build tools (e.g. Rust's `cargo`), they don't save their output to a file, so it's not possible to expose their results to `colcon` (e.g. saving test results for `colcon test-result`)