### PR TITLE
fix deprecated setuptools.config.read_configuration

### DIFF
--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -86,7 +86,10 @@ def get_configuration(setup_cfg):
     """
     try:
         # import locally to allow other functions in this module to be usable
-        from setuptools.config.setupcfg import read_configuration
+        try:
+            from setuptools.config.setupcfg import read_configuration
+        except ImportError:
+            from setuptools.config import read_configuration
     except ImportError as e:
         from pkg_resources import get_distribution
         from pkg_resources import parse_version

--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -86,7 +86,7 @@ def get_configuration(setup_cfg):
     """
     try:
         # import locally to allow other functions in this module to be usable
-        from setuptools.config import read_configuration
+        from setuptools.config.setupcfg import read_configuration
     except ImportError as e:
         from pkg_resources import get_distribution
         from pkg_resources import parse_version

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -91,6 +91,7 @@ scspell
 sdist
 searchability
 separarator
+setupcfg
 setuppy
 setupscript
 setuptools


### PR DESCRIPTION
Fix deprecations introduced in [setuptools V61.0.0](https://setuptools.pypa.io/en/latest/history.html#v61-0-0)

```
/home/user/colcon-venv/lib/python3.10/site-packages/setuptools/config/__init__.py:28: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
`setuptools.config.read_configuration` became deprecated.

For the time being, you can use the `setuptools.config.setupcfg` module
to access a backward compatible API, but this module is provisional
and might be removed in the future.
```
