### PR TITLE
Demote uncommon pytest extension packages to suggestions

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,7 @@
 [colcon-core]
 No-Python2:
 Depends3: python3-distlib, python3-empy, python3-pytest, python3-setuptools
-Recommends3: python3-pytest-cov, python3-pytest-repeat, python3-pytest-rerunfailures
+Recommends3: python3-pytest-cov
+Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
These extensions are not packaged for Ubuntu Bionic or Focal, and while it's still possible to install colcon with these recommendations present, the package is excluded from a normal 'apt upgrade' because of their absence. A 'dist-upgrade' works as expected, but we still want users to be able to upgrade normally.

Fixes: #495