### PR TITLE
Avoid deb_system and --install-layout deb

### DIFF
--- a/colcon_core/python_install_path.py
+++ b/colcon_core/python_install_path.py
@@ -18,7 +18,8 @@ def get_python_install_path(name, vars_=()):
     """
     kwargs = {}
     kwargs['vars'] = dict(vars_)
-    # Avoid deb_system because it ignores --prefix and hardcodes it to /usr
+    # Avoid deb_system because it means using --install-layout deb
+    # The latter ignores --prefix and hardcodes it to /usr
     if 'deb_system' in sysconfig.get_scheme_names():
         kwargs['scheme'] = 'posix_prefix'
 

--- a/colcon_core/python_install_path.py
+++ b/colcon_core/python_install_path.py
@@ -18,7 +18,8 @@ def get_python_install_path(name, vars_=()):
     """
     kwargs = {}
     kwargs['vars'] = dict(vars_)
+    # Avoid deb_system because it ignores --prefix and hardcodes it to /usr
     if 'deb_system' in sysconfig.get_scheme_names():
-        kwargs['scheme'] = 'deb_system'
+        kwargs['scheme'] = 'posix_prefix'
 
     return Path(sysconfig.get_path(name, **kwargs))

--- a/colcon_core/python_install_path.py
+++ b/colcon_core/python_install_path.py
@@ -19,7 +19,7 @@ def get_python_install_path(name, vars_=()):
     kwargs = {}
     kwargs['vars'] = dict(vars_)
     # Avoid deb_system because it means using --install-layout deb
-    # The latter ignores --prefix and hardcodes it to /usr
+    # which ignores --prefix and hardcodes it to /usr
     if 'deb_system' in sysconfig.get_scheme_names():
         kwargs['scheme'] = 'posix_prefix'
 

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -84,7 +84,6 @@ class PythonBuildTask(TaskExtensionPoint):
             if 'egg_info' in available_commands:
                 # prevent installation of dependencies specified in setup.py
                 cmd.append('--single-version-externally-managed')
-            self._append_install_layout(args, cmd)
             completed = await run(
                 self.context, cmd, cwd=args.path, env=env)
             if completed.returncode:
@@ -110,7 +109,6 @@ class PythonBuildTask(TaskExtensionPoint):
                 ]
                 if setup_py_data.get('data_files'):
                     cmd += ['install_data', '--install-dir', args.install_base]
-                self._append_install_layout(args, cmd)
                 completed = await run(
                     self.context, cmd, cwd=args.build_base, env=env)
             finally:
@@ -298,7 +296,3 @@ class PythonBuildTask(TaskExtensionPoint):
     def _get_python_lib(self, args):
         path = get_python_install_path('purelib', {'base': args.install_base})
         return os.path.relpath(path, start=args.install_base)
-
-    def _append_install_layout(self, args, cmd):
-        if 'dist-packages' in self._get_python_lib(args):
-            cmd += ['--install-layout', 'deb']

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -101,6 +101,7 @@ setupscript
 setuptools
 shlex
 sigint
+sloretz
 stacklevel
 staticmethod
 stdeb

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -41,6 +41,7 @@ getcategory
 getpid
 getpreferredencoding
 github
+hardcodes
 hookimpl
 hookwrapper
 https


### PR DESCRIPTION
Fixes #506

This PR avoids `--install-layout deb` and `deb_system`. I suspect these were never used before #504, and they have at least one bug that makes them unsuitable for colcon.

More info here: https://github.com/colcon/colcon-core/issues/506#issuecomment-1113874558