### PR TITLE
Drop unneeded nonlocal from pytest hook

### DIFF
--- a/colcon_core/pytest/hooks.py
+++ b/colcon_core/pytest/hooks.py
@@ -14,7 +14,6 @@ def pytest_terminal_summary(terminalreporter, exitstatus=None, config=None):
     summary_warnings = terminalreporter.summary_warnings
 
     def redirect_to_stderr(self):
-        nonlocal summary_warnings
         tw = self._tw
         import _pytest.config
         self._tw = _pytest.config.create_terminal_writer(


### PR DESCRIPTION
The nonlocal declaration is only needed when a variable is assigned to within a tighter scope. If the variable is only referenced but is not defined within the scope, Python should look for it in the higher scope without the declaration.

This change makes colcon-core's pytest hook compatible with Python 2. This is necessary to invoke Python 2 pytest while colcon is in a user's `PYTHONPATH`, where we're currently seeing a syntax error.