### PR TITLE
Add workaround for Fedora's rpm_prefix distribution patch

### DIFF
--- a/colcon_core/python_install_path.py
+++ b/colcon_core/python_install_path.py
@@ -22,5 +22,11 @@ def get_python_install_path(name, vars_=()):
     # which ignores --prefix and hardcodes it to /usr
     if 'deb_system' in sysconfig.get_scheme_names():
         kwargs['scheme'] = 'posix_prefix'
+    # The presence of the rpm_prefix scheme indicates that posix_prefix
+    # has been patched to inject `local` into the installation locations.
+    # The rpm_prefix scheme is a backup of what posix_prefix was before it was
+    # patched.
+    elif 'rpm_prefix' in sysconfig.get_scheme_names():
+        kwargs['scheme'] = 'rpm_prefix'
 
     return Path(sysconfig.get_path(name, **kwargs))


### PR DESCRIPTION
Similar to what Debian did when Ubuntu Jammy shipped, Fedora has patched CPython to override the installation directory for Python packages, presumably to avoid collision with the system-packaged Python modules.

Fedora's approach is slightly different, but can be patched around in a similar way.

Here's Fedora's patch: https://src.fedoraproject.org/rpms/python3.10/blob/fdfd6c1d945a381cbc85aa6d60b2369ac3ce7f50/f/00251-change-user-install-location.patch

Similar to #504