### PR TITLE
Explicitly specify Python installation directories

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -80,6 +80,12 @@ class PythonBuildTask(TaskExtensionPoint):
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),
                 'install', '--prefix', args.install_base,
+                '--install-lib', str(get_python_install_path(
+                    'purelib', {'base': args.install_base})),
+                '--install-scripts', str(get_python_install_path(
+                    'scripts', {'base': args.install_base})),
+                '--install-data', str(get_python_install_path(
+                    'data', {'base': args.install_base})),
                 '--record', os.path.join(args.build_base, 'install.log')]
             if 'egg_info' in available_commands:
                 # prevent installation of dependencies specified in setup.py


### PR DESCRIPTION
Since we're overriding the Python installation layout scheme in colcon, we shouldn't assume that setuptools is going to do the same thing. On Ubuntu Jammy, the system's setuptools package has a patch that seems to make it act how we want it to, but installing setuptools from pip without the system's patch causes these paths to change.

Rather than continue to attempt to predict setuptools' behavior, we should just specify the spots where we want the files manually.