### PR TITLE
Use sitecustomize to emulate venv during python install

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -21,6 +21,7 @@ from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_core.task.python import get_data_files_mapping
 from colcon_core.task.python import get_setup_data
+from colcon_core.task.python.template import expand_template
 
 logger = colcon_logger.getChild(__name__)
 
@@ -46,14 +47,23 @@ class PythonBuildTask(TaskExtensionPoint):
             return 1
         setup_py_data = get_setup_data(self.context.pkg, env)
 
+        # override installation locations
+        prefix_override = Path(args.build_base) / 'prefix_override'
+        expand_template(
+            Path(__file__).parent / 'template' / 'sitecustomize.py.em',
+            prefix_override / 'sitecustomize.py',
+            {
+                'site_prefix': args.install_base,
+            })
+
         # `setup.py develop|install` requires the python lib path to exist
         python_lib = os.path.join(
             args.install_base, self._get_python_lib(args))
         os.makedirs(python_lib, exist_ok=True)
         # and being in the PYTHONPATH
         env = dict(env)
-        env['PYTHONPATH'] = python_lib + os.pathsep + \
-            env.get('PYTHONPATH', '')
+        env['PYTHONPATH'] = str(prefix_override) + os.pathsep + \
+            python_lib + os.pathsep + env.get('PYTHONPATH', '')
 
         # determine if setuptools specific commands are available
         available_commands = await self._get_available_commands(
@@ -79,7 +89,7 @@ class PythonBuildTask(TaskExtensionPoint):
             cmd += [
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),
-                'install', '--prefix', args.install_base,
+                'install',
                 '--record', os.path.join(args.build_base, 'install.log')]
             if 'egg_info' in available_commands:
                 # prevent installation of dependencies specified in setup.py
@@ -102,14 +112,14 @@ class PythonBuildTask(TaskExtensionPoint):
                 # easy-install.pth file
                 cmd = [
                     executable, 'setup.py',
-                    'develop', '--prefix', args.install_base,
+                    'develop',
                     '--editable',
                     '--build-directory',
                     os.path.join(args.build_base, 'build'),
                     '--no-deps',
                 ]
                 if setup_py_data.get('data_files'):
-                    cmd += ['install_data', '--install-dir', args.install_base]
+                    cmd += ['install_data']
                 completed = await run(
                     self.context, cmd, cwd=args.build_base, env=env)
             finally:
@@ -163,7 +173,7 @@ class PythonBuildTask(TaskExtensionPoint):
         if os.path.exists(egg_info) and os.path.islink(setup_py_build_space):
             cmd = [
                 executable, 'setup.py',
-                'develop', '--prefix', args.install_base,
+                'develop',
                 '--uninstall', '--editable',
                 '--build-directory', os.path.join(args.build_base, 'build')
             ]

--- a/colcon_core/task/python/template/__init__.py
+++ b/colcon_core/task/python/template/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.shell.template import expand_template  # noqa: F401

--- a/colcon_core/task/python/template/sitecustomize.py.em
+++ b/colcon_core/task/python/template/sitecustomize.py.em
@@ -1,3 +1,3 @@
 import sys
 sys.real_prefix = sys.prefix
-sys.prefix = sys.exec_prefix = '@site_prefix'
+sys.prefix = sys.exec_prefix = @repr(site_prefix)

--- a/colcon_core/task/python/template/sitecustomize.py.em
+++ b/colcon_core/task/python/template/sitecustomize.py.em
@@ -1,0 +1,3 @@
+import sys
+sys.real_prefix = sys.prefix
+sys.prefix = sys.exec_prefix = '@site_prefix'

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,7 @@ pytest11 =
 
 [options.package_data]
 colcon_core.shell.template = *.em
+colcon_core.task.python.template = *.em
 
 [flake8]
 import-order-style = google

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -101,6 +101,7 @@ setupscript
 setuptools
 shlex
 sigint
+sitecustomize
 sloretz
 stacklevel
 staticmethod


### PR DESCRIPTION
During initialization, the `site` module probes for a `sitecustomize` module which performs site-specific initialization of various paths.

Python virtual environments modify sys.prefix in order to ensure that any attempted package installation ends up using the virtual environment instead of the system locations.

This approach should prevent various Linux distributions' attempts to inject `local` into the installation locations for python packages. They seem to have special cases for detecting virtual environments and omit the custom logic when detected.

This is a potentially disruptive change. It modifies some of the core installation logic for python packages. However, some popular Linux distributions (Looking at you, [Debian](https://salsa.debian.org/cpython-team/python3/-/blob/99b2210c1ad46213b622d01e8130e8d279db4fa6/debian/patches/sysconfig-debian-schemes.diff) and [Fedora](https://src.fedoraproject.org/rpms/python3.10/blob/fdfd6c1d945a381cbc85aa6d60b2369ac3ce7f50/f/00251-change-user-install-location.patch)) have really backed us into a corner by patching `sysconfig.py` to inject `local` into various paths, and this seems to be one of the only ways I can find to avoid that behavior consistently.

This is the specific part of `site.py` that inspired this change: https://github.com/python/cpython/blob/a24e67697362e76dd25d6901109277458b5971b9/Lib/site.py#L529

Some things we need to cover when testing this:
1. Many platforms, but mainly Ubuntu Jammy and Fedora 36, where the new patches are causing problems.
2. With the system-shipped `setuptools` and also with bleeding-edge pip-installed `setuptools`.
3. Invoking `colcon` from within, or referencing packages in:
   * a virtual environment
   * a user base directory (i.e. `~/.local`)
4. ~~Python 2~~ **ROS 1 python packages are wrapped by cmake and are unaffected by this change**

Some canary CI builds:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16699)](http://ci.ros2.org/job/ci_linux/16699/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11281)](http://ci.ros2.org/job/ci_linux-aarch64/11281/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=229)](http://ci.ros2.org/job/ci_linux-rhel/229/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17096)](http://ci.ros2.org/job/ci_windows/17096/)

Normal jobs on ci.ros2.org will use a python virtual environment, which triggers different code paths in the Debian patch. I augmented some `test_ci_linux` jobs to not use a virtualenv so that we could properly test this.

With updated `setuptools`:
* Linux (without this change): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_linux&build=117)](http://ci.ros2.org/job/test_ci_linux/117/)
* Linux (with this change): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=test_ci_linux&build=118)](http://ci.ros2.org/job/test_ci_linux/118/)