### PR TITLE
Add sysconfig scheme workaround for osx_framework_library

### DIFF
--- a/colcon_core/python_install_path.py
+++ b/colcon_core/python_install_path.py
@@ -20,7 +20,8 @@ def get_python_install_path(name, vars_=()):
     kwargs['vars'] = dict(vars_)
     # Avoid deb_system because it means using --install-layout deb
     # which ignores --prefix and hardcodes it to /usr
-    if 'deb_system' in sysconfig.get_scheme_names():
+    if 'deb_system' in sysconfig.get_scheme_names() or \
+            'osx_framework_library' in sysconfig.get_scheme_names():
         kwargs['scheme'] = 'posix_prefix'
 
     return Path(sysconfig.get_path(name, **kwargs))


### PR DESCRIPTION
The Homebrew folks took a similar approach to Debian's patch, but it's worse because their `purelib` completely disregards `{prefix}` entirely, meaning that colcon is attempting to install stuff into Homebrew's prefix path.

See https://github.com/Homebrew/homebrew-core/blob/2f008323193f636d32c4a970caa9e8b528c6c430/Formula/python%403.10.rb#L62-L68