### PR TITLE
Revert "Use sitecustomize to emulate venv during python install"

### DIFF
--- a/colcon_core/task/python/template/__init__.py
+++ b/colcon_core/task/python/template/__init__.py
@@ -1,4 +1,0 @@
-# Copyright 2022 Open Source Robotics Foundation, Inc.
-# Licensed under the Apache License, Version 2.0
-
-from colcon_core.shell.template import expand_template  # noqa: F401

--- a/colcon_core/task/python/template/sitecustomize.py.em
+++ b/colcon_core/task/python/template/sitecustomize.py.em
@@ -1,3 +1,0 @@
-import sys
-sys.real_prefix = sys.prefix
-sys.prefix = sys.exec_prefix = @repr(site_prefix)

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,7 +145,6 @@ pytest11 =
 
 [options.package_data]
 colcon_core.shell.template = *.em
-colcon_core.task.python.template = *.em
 
 [flake8]
 import-order-style = google

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -101,7 +101,6 @@ setupscript
 setuptools
 shlex
 sigint
-sitecustomize
 sloretz
 stacklevel
 staticmethod


### PR DESCRIPTION
This reverts #512.
Fixes #518.

There is a conditional in `setuptools` that causes some `setup.cfg` options to be ignored while in a virtual environment. While their use is probably incorrect, the anitpattern is too widespread to ignore, and we can't see a way to avoid the conditional in setuptools while still using the `sitecustomize` approach to work around the platform patches.

This will regress colcon builds on Fedora 36, homebrew, and Jammy with `setuptools` installed from pip once again, until we can come up with a new solution.