### PR TITLE
Extract and explicitly pass install-scripts to setuptools

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -14,6 +14,7 @@ changelog
 classname
 colcon
 coloredlogs
+configparser
 contextlib
 coroutine
 coroutines
@@ -61,6 +62,7 @@ noops
 noqa
 notestscollected
 openpty
+optionxform
 pathlib
 pkgname
 pkgs

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -50,6 +50,7 @@ isatty
 iterdir
 junit
 levelname
+libexec
 lineno
 linux
 lstrip


### PR DESCRIPTION
When part of a virtual environment, this option is specifically ignored in configuration files by setuptools, but not on the command line.

This is an actual fix for #518, which wasn't actually fixed by #520 but rather made it far less common.

The test added here doesn't actually create a virtual environment to validate the conditions which motivated this fix, but the test will fail if run under a virtual environment without this fix.