### PR TITLE
Revert "Revert "Use sitecustomize to emulate venv during python install""

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -22,6 +22,7 @@ from colcon_core.task import run
 from colcon_core.task import TaskExtensionPoint
 from colcon_core.task.python import get_data_files_mapping
 from colcon_core.task.python import get_setup_data
+from colcon_core.task.python.template import expand_template
 
 logger = colcon_logger.getChild(__name__)
 
@@ -58,14 +59,23 @@ class PythonBuildTask(TaskExtensionPoint):
             return 1
         setup_py_data = get_setup_data(self.context.pkg, env)
 
+        # override installation locations
+        prefix_override = Path(args.build_base) / 'prefix_override'
+        expand_template(
+            Path(__file__).parent / 'template' / 'sitecustomize.py.em',
+            prefix_override / 'sitecustomize.py',
+            {
+                'site_prefix': args.install_base,
+            })
+
         # `setup.py develop|install` requires the python lib path to exist
         python_lib = os.path.join(
             args.install_base, self._get_python_lib(args))
         os.makedirs(python_lib, exist_ok=True)
         # and being in the PYTHONPATH
         env = dict(env)
-        env['PYTHONPATH'] = python_lib + os.pathsep + \
-            env.get('PYTHONPATH', '')
+        env['PYTHONPATH'] = str(prefix_override) + os.pathsep + \
+            python_lib + os.pathsep + env.get('PYTHONPATH', '')
 
         # determine if setuptools specific commands are available
         available_commands = await self._get_available_commands(
@@ -91,7 +101,7 @@ class PythonBuildTask(TaskExtensionPoint):
             cmd += [
                 'build', '--build-base', os.path.join(
                     args.build_base, 'build'),
-                'install', '--prefix', args.install_base,
+                'install',
                 '--record', os.path.join(args.build_base, 'install.log')]
             # Extract and explicitly pass install-scripts to setuptools.
             # When part of a virtual environment, this option is specifically
@@ -121,14 +131,14 @@ class PythonBuildTask(TaskExtensionPoint):
                 # easy-install.pth file
                 cmd = [
                     executable, 'setup.py',
-                    'develop', '--prefix', args.install_base,
+                    'develop',
                     '--editable',
                     '--build-directory',
                     os.path.join(args.build_base, 'build'),
                     '--no-deps',
                 ]
                 if setup_py_data.get('data_files'):
-                    cmd += ['install_data', '--install-dir', args.install_base]
+                    cmd += ['install_data']
                 completed = await run(
                     self.context, cmd, cwd=args.build_base, env=env)
             finally:
@@ -182,7 +192,7 @@ class PythonBuildTask(TaskExtensionPoint):
         if os.path.exists(egg_info) and os.path.islink(setup_py_build_space):
             cmd = [
                 executable, 'setup.py',
-                'develop', '--prefix', args.install_base,
+                'develop',
                 '--uninstall', '--editable',
                 '--build-directory', os.path.join(args.build_base, 'build')
             ]

--- a/colcon_core/task/python/template/__init__.py
+++ b/colcon_core/task/python/template/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.shell.template import expand_template  # noqa: F401

--- a/colcon_core/task/python/template/sitecustomize.py.em
+++ b/colcon_core/task/python/template/sitecustomize.py.em
@@ -1,0 +1,3 @@
+import sys
+sys.real_prefix = sys.prefix
+sys.prefix = sys.exec_prefix = @repr(site_prefix)

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,7 @@ pytest11 =
 
 [options.package_data]
 colcon_core.shell.template = *.em
+colcon_core.task.python.template = *.em
 
 [flake8]
 import-order-style = google

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -104,6 +104,7 @@ setupscript
 setuptools
 shlex
 sigint
+sitecustomize
 sloretz
 stacklevel
 staticmethod


### PR DESCRIPTION
The problem which necessitated this revert should be resolved independently by #530, meaning we can re-apply this change and take another shot at solving our problems with platform patches to Python paths.

This restores #512
This reverts #520
Closes #519