### PR TITLE
Stop using 'echo' in shell test

### DIFF
--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -4,6 +4,7 @@
 from collections import OrderedDict
 import os
 from pathlib import Path
+import sys
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -124,7 +125,8 @@ def test_get_command_environment():
 
 def test_get_environment_variables():
     cmd = [
-        'echo', 'FOO\nNAME=value\n\nSOMETHING\nNAME2=value with spaces']
+        sys.executable, '-c',
+        r'print("FOO\nNAME=value\n\nSOMETHING\nNAME2=value with spaces")']
 
     coroutine = get_environment_variables(cmd, shell=False)
     env = run_until_complete(coroutine)


### PR DESCRIPTION
On Linux, 'echo' is an executable. On Windows, 'echo' is a shell command. Even if we enable the shell while executing this test, the command acts differently on Windows and it is difficult to get it to print newlines as is required by this test.

In any case, we can just use the python executable to print the text instead, which is obviously available during testing.

I'm guessing that this isn't breaking in our windows CI because one of the tools installed in the Windows agents is providing the 'echo' binary on `PATH`. I found this bug while bootstrapping colcon in a minimal Windows environment.