### PR TITLE
Deprecate colcon_core.task.python.test.has_test_dependency()

### DIFF
--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -3,6 +3,7 @@
 
 import re
 import traceback
+import warnings
 
 from colcon_core.entry_point import load_entry_points
 from colcon_core.logging import colcon_logger
@@ -217,6 +218,10 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
+    warnings.warn(
+        "'colcon_core.task.python.test.has_test_dependency()' "
+        "has been deprecated, use dependencies['test'] from the "
+        'associated package descriptor instead', stacklevel=2)
     tests_require = extract_dependencies(setup_py_data).get('test')
     for d in tests_require or []:
         # the name might be followed by a version

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -10,7 +10,6 @@ from colcon_core.event.test import TestFailure
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_core.task import run
-from colcon_core.task.python.test import has_test_dependency
 from colcon_core.task.python.test import PythonTestingStepExtensionPoint
 from colcon_core.verb.test import logger
 from pkg_resources import parse_version
@@ -47,7 +46,8 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             help='Generate coverage information')
 
     def match(self, context, env, setup_py_data):  # noqa: D102
-        return has_test_dependency(setup_py_data, 'pytest')
+        test_deps = context.pkg.dependencies.get('test') or set()
+        return 'pytest' in test_deps
 
     async def step(self, context, env, setup_py_data):  # noqa: D102
         cmd = [sys.executable, '-m', 'pytest']
@@ -71,9 +71,10 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             ]
         env = dict(env)
 
+        test_deps = context.pkg.dependencies.get('test') or set()
         if (
             context.args.pytest_with_coverage or
-            has_test_dependency(setup_py_data, 'pytest-cov')
+            'pytest-cov' in test_deps
         ):
             try:
                 from pytest_cov import __version__ as pytest_cov_version

--- a/test/test_task_python_test_pytest.py
+++ b/test/test_task_python_test_pytest.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.task import TaskContext
 from colcon_core.task.python import get_setup_data
@@ -17,33 +18,20 @@ def test_pytest_match():
     desc.type = 'python'
 
     # no test requirements
-    desc.metadata['get_python_setup_options'] = lambda env: {}
     assert not extension.match(context, env, get_setup_data(desc, env))
 
-    # pytest not in tests_require
-    desc.metadata['get_python_setup_options'] = lambda env: {
-        'tests_require': ['nose'],
+    # empty test requirements
+    desc.dependencies['test'] = {}
+    assert not extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest not in test requirements
+    desc.dependencies['test'] = {
+        DependencyDescriptor('nose'),
     }
     assert not extension.match(context, env, get_setup_data(desc, env))
 
-    # pytest not in extras_require.test
-    desc.metadata['get_python_setup_options'] = lambda env: {
-        'extras_require': {
-            'test': ['nose']
-        },
-    }
-    assert not extension.match(context, env, get_setup_data(desc, env))
-
-    # pytest in tests_require
-    desc.metadata['get_python_setup_options'] = lambda env: {
-        'tests_require': ['pytest'],
-    }
-    assert extension.match(context, env, get_setup_data(desc, env))
-
-    # pytest in extras_require.test
-    desc.metadata['get_python_setup_options'] = lambda env: {
-        'extras_require': {
-            'test': ['pytest']
-        },
+    # pytest in test requirements
+    desc.dependencies['test'] = {
+        DependencyDescriptor('pytest'),
     }
     assert extension.match(context, env, get_setup_data(desc, env))


### PR DESCRIPTION
All of the information and functionality provided by has_test_dependency is already employed by PythonPackageAugmentation when enumerating the dependencies of the package. It's more efficient and flexible, and results in less duplication of information to just read the dependencies from there.

I found no uses of `has_test_dependency` outside of `colcon-core`.