### PR TITLE
Specifically exclude flake8>=6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ zip_safe = false
 
 [options.extras_require]
 test =
-  flake8>=3.6.0
+  flake8>=3.6.0,<6
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
colcon/ci#11 worked fine for the rest of the colcon repositories, but `colcon-core` also performs a bootstrap test which is having this same problem. Rather than employ another `constraints.txt`, it's easier and more correct to express the constraint in the dependency itself.

...until we come up with a long-term solution, that is.