### PR TITLE
Return list of generated files from create_environment_scripts

### DIFF
--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -41,7 +41,7 @@ class ShellExtensionPoint:
     """
 
     """The version of the shell extension interface."""
-    EXTENSION_POINT_VERSION = '2.1'
+    EXTENSION_POINT_VERSION = '2.2'
 
     """
     The default priority of shell extensions.
@@ -133,6 +133,8 @@ class ShellExtensionPoint:
         :param Path prefix_path: The path of the install prefix
         :param bool merge_install: The flag if all packages share the same
           install prefix
+        :returns: The relative paths to the created scripts
+        :rtype: list
         """
         raise NotImplementedError()
 
@@ -168,6 +170,8 @@ class ShellExtensionPoint:
         :param Path prefix_path: The package specific install prefix
         :param str pkg_name: The package name
         :param list hooks: The relative paths to the hook scripts
+        :returns: The relative paths to the created scripts
+        :rtype: list
         """
         raise NotImplementedError()
 

--- a/colcon_core/shell/bat.py
+++ b/colcon_core/shell/bat.py
@@ -34,7 +34,7 @@ class BatShell(ShellExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.1')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.2')
         if sys.platform != 'win32' and not shell.use_all_shell_extensions:
             raise SkipExtensionException('Not used on non-Windows systems')
 
@@ -68,6 +68,12 @@ class BatShell(ShellExtensionPoint):
                 'prefix_script_no_ext': 'local_setup',
             })
 
+        return [
+            prefix_env_path,
+            prefix_util_path,
+            prefix_chain_env_path,
+        ]
+
     def create_package_script(  # noqa: D102
         self, prefix_path, pkg_name, hooks
     ):
@@ -80,6 +86,7 @@ class BatShell(ShellExtensionPoint):
                 'hooks': list(filter(
                     lambda hook: str(hook[0]).endswith('.bat'), hooks)),
             })
+        return [pkg_env_path]
 
     def create_hook_set_value(  # noqa: D102
         self, env_hook_name, prefix_path, pkg_name, name, value,

--- a/colcon_core/shell/dsv.py
+++ b/colcon_core/shell/dsv.py
@@ -17,10 +17,10 @@ class DsvShell(ShellExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.0')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.2')
 
     def create_prefix_script(self, prefix_path, merge_install):  # noqa: D102
-        pass
+        return []
 
     def create_package_script(  # noqa: D102
         self, prefix_path, pkg_name, hooks
@@ -33,6 +33,7 @@ class DsvShell(ShellExtensionPoint):
             {
                 'hooks': hooks,
             })
+        return [pkg_env_path]
 
     def create_hook_set_value(  # noqa: D102
         self, env_hook_name, prefix_path, pkg_name, name, value,

--- a/colcon_core/shell/sh.py
+++ b/colcon_core/shell/sh.py
@@ -33,7 +33,7 @@ class ShShell(ShellExtensionPoint):
 
     def __init__(self):  # noqa: D107
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.1')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.2')
         if sys.platform == 'win32' and not shell.use_all_shell_extensions:
             raise SkipExtensionException('Not used on Windows systems')
 
@@ -69,6 +69,12 @@ class ShShell(ShellExtensionPoint):
                 'prefix_script_no_ext': 'local_setup',
             })
 
+        return [
+            prefix_env_path,
+            prefix_util_path,
+            prefix_chain_env_path,
+        ]
+
     def create_package_script(  # noqa: D102
         self, prefix_path, pkg_name, hooks
     ):
@@ -82,6 +88,7 @@ class ShShell(ShellExtensionPoint):
                 'hooks': list(filter(
                     lambda hook: str(hook[0]).endswith('.sh'), hooks)),
             })
+        return [pkg_env_path]
 
     def create_hook_set_value(  # noqa: D102
         self, env_hook_name, prefix_path, pkg_name, name, value,

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -215,10 +215,12 @@ class BuildVerb(VerbExtensionPoint):
             extensions_same_prio = extensions[priority]
             for extension in extensions_same_prio.values():
                 try:
-                    retval = extension.create_prefix_script(
+                    scripts = extension.create_prefix_script(
                         Path(install_base), merge_install)
-                    assert retval is None, \
-                        'create_prefix_script() should return None'
+                    # TODO: Disallow 'None' in v3.0 of ShellExtensionPoint
+                    if scripts is not None:
+                        assert isinstance(scripts, list), \
+                            'create_prefix_script() should return a list'
                 except Exception as e:  # noqa: F841
                     # catch exceptions raised in shell extension
                     exc = traceback.format_exc()

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -85,7 +85,7 @@ def test_create_environment_scripts():
             assert len(error.call_args[0]) == 1
             assert error.call_args[0][0].startswith(
                 "Exception in shell extension 'extension3': "
-                'create_package_script() should return None\n')
+                'create_package_script() should return a list\n')
             # check for correct hooks argument
             mock = extensions[100]['extension4'].create_package_script
             assert mock.call_count == 1


### PR DESCRIPTION
The create_environment_scripts function writes package-specific files to disk based on available shell extensions. This change causes that function, and the functions it calls in ShellExtension instances, to return a list of files which were actually written.

This can be useful in downstream processes to understand what files were installed as part of the package, which could facilitate uninstalling those packages properly.

This change includes a minor version bump to the ShellExtensionPoint. Existing implementations of ShellExtensionPoint will not be broken by this change, but the files they write will not be included in the list until they update to the new extension point API.

Consumers of the ShellExtensionPoint API are all updated within this change.

Implementations to be updated separately after this change has been merged and released:
- [colcon-bash](https://github.com/colcon/colcon-bash)
- [colcon-powershell](https://github.com/colcon/colcon-powershell)
- [colcon-zsh](https://github.com/colcon/colcon-zsh)