### PR TITLE
Fix some tests which modify global state

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -41,6 +41,7 @@ functools
 getcategory
 getpid
 getpreferredencoding
+getsignal
 github
 hardcodes
 hookimpl

--- a/test/test_executor_sequential.py
+++ b/test/test_executor_sequential.py
@@ -154,7 +154,14 @@ async def job8():
     ran_jobs.append('job8')
 
 
-def test_sequential_keyboard_interrupt():
+@pytest.fixture
+def restore_sigint_handler():
+    handler = signal.getsignal(signal.SIGINT)
+    yield
+    signal.signal(signal.SIGINT, handler)
+
+
+def test_sequential_keyboard_interrupt(restore_sigint_handler):
     global ran_jobs
 
     if sys.platform == 'win32':

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -97,7 +97,14 @@ def test_log_path():
     assert get_log_path() == Path(log_base_path) / subdirectory
 
 
-def test_create_log_path():
+@pytest.fixture
+def reset_log_path_creation_global():
+    yield
+    from colcon_core import location
+    location._reset_log_path_creation_global()
+
+
+def test_create_log_path(reset_log_path_creation_global):
     subdirectory = 'sub'
     with TemporaryDirectory(prefix='test_colcon_') as log_path:
         log_path = Path(log_path)


### PR DESCRIPTION
These two tests modify the global state in a way that makes them runnable only once. This renders colcon's own `--retest-until-fail` feature useless, so this change adds fixtures to restore the state after the test concludes.