### PR TITLE
Switch to $GITHUB_OUTPUT over deprecated ::set-output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: colcon/ci
       - id: load
-        run: echo "::set-output name=strategy::$(echo $(cat strategy.json))"
+        run: echo "strategy=$(echo $(cat strategy.json))" >> $GITHUB_OUTPUT
 
   pytest:
     needs: [setup]


### PR DESCRIPTION
In response to: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/