### PR TITLE
Update GitHub Actions major versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       strategy: ${{steps.load.outputs.strategy}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: colcon/ci
       - id: load
@@ -24,12 +24,12 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python}}
       - uses: colcon/ci@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
 
   bootstrap:
     needs: [setup]
@@ -37,8 +37,8 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python}}
       - name: Install dependencies


### PR DESCRIPTION
We don't have a particlarly tight coupling to any of these actions, and they're starting to throw deprecation warnings due to deprecations in their internal dependencies.