### PR TITLE
Address some new flake8 violations due to pydocstyle 6.2.0

### DIFF
--- a/test/test_plugin_system.py
+++ b/test/test_plugin_system.py
@@ -141,12 +141,12 @@ def test_get_first_line_doc():
     assert get_first_line_doc(no_doc) == ''
 
     def whitespace_doc():
-        """ """
+        """ """  # noqa: D419
     assert get_first_line_doc(whitespace_doc) == ''
 
     def empty_lines_doc():
         """
-        """
+        """  # noqa: D419
     assert get_first_line_doc(empty_lines_doc) == ''
 
 


### PR DESCRIPTION
These violations occur in test code which requires suppression of the linter.