### PR TITLE
Revert "Deprecate colcon_core.task.python.test.has_test_dependency()"

### DIFF
--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -3,7 +3,6 @@
 
 import re
 import traceback
-import warnings
 
 from colcon_core.entry_point import load_entry_points
 from colcon_core.logging import colcon_logger
@@ -218,10 +217,6 @@ def has_test_dependency(setup_py_data, name):
       False otherwise
     :rtype: bool
     """
-    warnings.warn(
-        "'colcon_core.task.python.test.has_test_dependency()' "
-        "has been deprecated, use dependencies['test'] from the "
-        'associated package descriptor instead', stacklevel=2)
     tests_require = extract_dependencies(setup_py_data).get('test')
     for d in tests_require or []:
         # the name might be followed by a version

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -10,6 +10,7 @@ from colcon_core.event.test import TestFailure
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_core.task import run
+from colcon_core.task.python.test import has_test_dependency
 from colcon_core.task.python.test import PythonTestingStepExtensionPoint
 from colcon_core.verb.test import logger
 from pkg_resources import parse_version
@@ -46,8 +47,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             help='Generate coverage information')
 
     def match(self, context, env, setup_py_data):  # noqa: D102
-        test_deps = context.pkg.dependencies.get('test') or set()
-        return 'pytest' in test_deps
+        return has_test_dependency(setup_py_data, 'pytest')
 
     async def step(self, context, env, setup_py_data):  # noqa: D102
         cmd = [sys.executable, '-m', 'pytest']
@@ -71,10 +71,9 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             ]
         env = dict(env)
 
-        test_deps = context.pkg.dependencies.get('test') or set()
         if (
             context.args.pytest_with_coverage or
-            'pytest-cov' in test_deps
+            has_test_dependency(setup_py_data, 'pytest-cov')
         ):
             try:
                 from pytest_cov import __version__ as pytest_cov_version

--- a/test/test_task_python_test_pytest.py
+++ b/test/test_task_python_test_pytest.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
-from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.task import TaskContext
 from colcon_core.task.python import get_setup_data
@@ -18,20 +17,33 @@ def test_pytest_match():
     desc.type = 'python'
 
     # no test requirements
+    desc.metadata['get_python_setup_options'] = lambda env: {}
     assert not extension.match(context, env, get_setup_data(desc, env))
 
-    # empty test requirements
-    desc.dependencies['test'] = {}
-    assert not extension.match(context, env, get_setup_data(desc, env))
-
-    # pytest not in test requirements
-    desc.dependencies['test'] = {
-        DependencyDescriptor('nose'),
+    # pytest not in tests_require
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'tests_require': ['nose'],
     }
     assert not extension.match(context, env, get_setup_data(desc, env))
 
-    # pytest in test requirements
-    desc.dependencies['test'] = {
-        DependencyDescriptor('pytest'),
+    # pytest not in extras_require.test
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'extras_require': {
+            'test': ['nose']
+        },
+    }
+    assert not extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest in tests_require
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'tests_require': ['pytest'],
+    }
+    assert extension.match(context, env, get_setup_data(desc, env))
+
+    # pytest in extras_require.test
+    desc.metadata['get_python_setup_options'] = lambda env: {
+        'extras_require': {
+            'test': ['pytest']
+        },
     }
     assert extension.match(context, env, get_setup_data(desc, env))


### PR DESCRIPTION
It turns out that this mechanism is used to communicate the Python-type dependencies from the setuptools options when processing ament_python packages, which otherwise have ROS-type dependencies. So while we're seeing `python3-pytest` in the test dependency list, the pure python code here looks for the pure python dependency `pytest`.

Since this doesn't actually save us much time and is clearly still needed, I'll take the same approach in the Python project code as was taken in ament_python so that we can all use the same Python testing task.

This reverts #536.