### PR TITLE
Tweak pkg_resources deprecation suppression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ filterwarnings =
     error
     # Suppress deprecation warnings in other packages
     ignore:lib2to3 package is deprecated::scspell
-    ignore:pkg_resources is deprecated as an API::pkg_resources
+    ignore:pkg_resources is deprecated as an API
     ignore:SelectableGroups dict interface is deprecated::flake8
     ignore:The loop argument is deprecated::asyncio
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pydocstyle


### PR DESCRIPTION
They must have changed the stacklevel on this warning or something, because this suppression worked at some point. In any case, we need this suppressed to get CI on the multi-part effort to move away from `pkg_resources`.