### PR TITLE
Add 'origin' metadata to python dependencies

### DIFF
--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -123,7 +123,9 @@ def create_dependency_descriptor(requirement_string):
     }
 
     requirement = parse_requirement(requirement_string)
-    metadata = {}
+    metadata = {
+        'origin': 'python',
+    }
     for symbol, version in (requirement.constraints or []):
         if symbol in symbol_mapping:
             metadata[symbol_mapping[symbol]] = version


### PR DESCRIPTION
While I don't think we should discriminate between dependency types for general use, this is useful metadata in some contexts and is easy to include.