### PR TITLE
Omit runtime dependencies from build ordering

### DIFF
--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -71,16 +71,20 @@ class PackageDescriptor:
         :raises AssertionError: if the package name is listed as a dependency
         """
         dependencies = set()
+        categories_by_dependency = defaultdict(list)
         if categories is None:
             categories = self.dependencies.keys()
         for category in sorted(categories):
-            dependencies |= self.dependencies[category]
+            for dependency in self.dependencies[category]:
+                categories_by_dependency[dependency].append(category)
+        for dependency, categories in categories_by_dependency.items():
+            if not isinstance(dependency, DependencyDescriptor):
+                dependency = DependencyDescriptor(dependency)
+            dependency.metadata['categories'] = categories
+            dependencies.add(dependency)
         assert self.name not in dependencies, \
             f"The package '{self.name}' has a dependency with the same name"
-        return {
-            (DependencyDescriptor(d)
-                if not isinstance(d, DependencyDescriptor) else d)
-            for d in dependencies}
+        return dependencies
 
     def get_recursive_dependencies(
         self, descriptors, direct_categories=None, recursive_categories=None,

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -182,6 +182,9 @@ class BuildVerb(VerbExtensionPoint):
 
             recursive_dependencies = OrderedDict()
             for dep_name in decorator.recursive_dependencies:
+                if dep_name.metadata.get('depth') == 1:
+                    if dep_name.metadata.get('categories') == ['run']:
+                        continue
                 dep_path = install_base
                 if not args.merge_install:
                     dep_path = os.path.join(dep_path, dep_name)


### PR DESCRIPTION
This change will allow a package which has only a runtime dependency on another package to be built independently. It will not affect the dependency-based package selection behavior, but could make the build graph a little more shallow.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19277)](https://ci.ros2.org/job/ci_linux/19277/)