### PR TITLE
Avoid race condition in event_reactor test

### DIFF
--- a/test/test_event_reactor.py
+++ b/test/test_event_reactor.py
@@ -66,15 +66,15 @@ def test_create_event_reactor():
             assert error.call_count == 0
 
             queue.put(('first', None))
-            event_reactor.flush()
+            queue.join()
             assert error.call_count == 1
 
             queue.put(('second', None))
-            event_reactor.flush()
+            queue.join()
             assert error.call_count == 1
 
             queue.put(('third', None))
-            event_reactor.flush()
+            queue.join()
             assert error.call_count == 2
 
         # 1 timer event, 3 mock string events


### PR DESCRIPTION
These tests essentially queue an event, wait for the event reactor to process the event, and check that an appropriate function was or was not called. The way we were previously waiting for the event reactor thread to do the work left a window between popping the work from the queue and actually passing the event to the observers. If the flush loop finished early in this window, there was a chance that the test's assert would beat the event reactor, which hadn't yet invoked the observers.

Rather than change the behavior of the flush function to also ensure that the popped work had completed processing, we can simply use the queue's integrated work tracking, which won't unblock until there is no work in the queue OR processing.

I believe that this is the cause of the sporadic CI failures in this repository.