### PR TITLE
Drop Windows event loop hack in Python 3.8+

### DIFF
--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -92,9 +92,11 @@ class SequentialExecutor(ExecutorExtensionPoint):
                 if not task.done():
                     logger.error(f"Task '{task}' not done")
             # HACK on Windows closing the event loop seems to hang after Ctrl-C
-            # even though no futures are pending
-            if sys.platform != 'win32':
+            # even though no futures are pending, but appears fixed in py3.8
+            if sys.platform != 'win32' or sys.version_info >= (3, 8):
                 logger.debug('closing loop')
                 loop.close()
                 logger.debug('loop closed')
+            else:
+                logger.debug('skipping loop closure')
         return rc


### PR DESCRIPTION
In Python versions prior to 3.8, it appears that attempting to close the event loop after a Ctrl-C would reliably hang the process, which would need to be killed.

I've been unable to reproduce the behavior in any newer Python versions, so I think it's time to set the timeline for removing the hack entirely.

This should take care of the common ResourceWarning messages when using newer Python versions.