### PR TITLE
Use default event loop on Windows in Python 3.8

### DIFF
--- a/colcon_core/subprocess.py
+++ b/colcon_core/subprocess.py
@@ -37,7 +37,8 @@ def new_event_loop():
 
     :returns: The created event loop
     """
-    if sys.platform == 'win32':
+    # TODO: Drop this along with py3.7
+    if sys.platform == 'win32' and sys.version_info < (3, 8):
         return asyncio.ProactorEventLoop()
     return asyncio.new_event_loop()
 


### PR DESCRIPTION
In Python 3.8 and newer, the default event loop on Windows is the ProactorEventLoop, so there's no reason to specifically create one here. We can drop this conditional entirely when we drop Python 3.7 support.