### PR TITLE
Resolve path arguments when specified on command line

### DIFF
--- a/colcon_core/argument_type.py
+++ b/colcon_core/argument_type.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import functools
+import os
+
+from colcon_core.argument_default import is_default_value
+
+
+def resolve_path(value, base=os.getcwd()):
+    """
+    Resolve a path argument from the current directory.
+
+    If the given value is an argument default, the value is returned
+    unmodified.
+
+    :param value: The value to resolve to an absolute path
+    :returns: The unmodified value, or resolved path
+    """
+    if value is None or is_default_value(value):
+        return value
+    res = os.path.abspath(os.path.join(base, str(value)))
+    return res
+
+
+def get_cwd_path_resolver():
+    """
+    Create a function which resolves paths from the current directory.
+
+    If the current directory changes between calling this function and calling
+    the function returned by this function, the directory at the time of this
+    function call is used.
+
+    :returns: A function which takes a single string and returns a string
+    """
+    return functools.partial(resolve_path, base=os.getcwd())

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -5,6 +5,7 @@ import os
 
 from colcon_core.argument_default import is_default_value
 from colcon_core.argument_default import wrap_default_value
+from colcon_core.argument_type import get_cwd_path_resolver
 from colcon_core.package_discovery import expand_dir_wildcards
 from colcon_core.package_discovery import logger
 from colcon_core.package_discovery import PackageDiscoveryExtensionPoint
@@ -32,6 +33,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
             nargs='*' if not single_path else '?',
             metavar='PATH',
             default=wrap_default_value(['.']) if with_default else None,
+            type=get_cwd_path_resolver(),
             help='The paths to check for a package. Use shell wildcards '
                  '(e.g. `src/*`) to select all direct subdirectories' +
                  (' (default: .)' if with_default else ''))

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -7,8 +7,10 @@ import os.path
 from pathlib import Path
 import traceback
 
+from colcon_core.argument_default import wrap_default_value
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
+from colcon_core.argument_type import get_cwd_path_resolver
 from colcon_core.event.job import JobUnselected
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.executor import add_executor_arguments
@@ -83,11 +85,13 @@ class BuildVerb(VerbExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--build-base',
-            default='build',
+            default=wrap_default_value('build'),
+            type=get_cwd_path_resolver(),
             help='The base path for all build directories (default: build)')
         parser.add_argument(
             '--install-base',
-            default='install',
+            default=wrap_default_value('install'),
+            type=get_cwd_path_resolver(),
             help='The base path for all install prefixes (default: install)')
         parser.add_argument(
             '--merge-install',
@@ -99,6 +103,7 @@ class BuildVerb(VerbExtensionPoint):
             help='Use symlinks instead of copying files where possible')
         parser.add_argument(
             '--test-result-base',
+            type=get_cwd_path_resolver(),
             help='The base path for all test results (default: --build-base)')
         parser.add_argument(
             '--continue-on-error',

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -5,8 +5,10 @@ from collections import OrderedDict
 import os
 import types
 
+from colcon_core.argument_default import wrap_default_value
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
+from colcon_core.argument_type import get_cwd_path_resolver
 from colcon_core.event.test import TestFailure
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.executor import add_executor_arguments
@@ -85,11 +87,13 @@ class TestVerb(VerbExtensionPoint):
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
             '--build-base',
-            default='build',
+            default=wrap_default_value('build'),
+            type=get_cwd_path_resolver(),
             help='The base path for all build directories (default: build)')
         parser.add_argument(
             '--install-base',
-            default='install',
+            default=wrap_default_value('install'),
+            type=get_cwd_path_resolver(),
             help='The base path for all install prefixes (default: install)')
         parser.add_argument(
             '--merge-install',
@@ -97,6 +101,7 @@ class TestVerb(VerbExtensionPoint):
             help='Merge all install prefixes into a single location')
         parser.add_argument(
             '--test-result-base',
+            type=get_cwd_path_resolver(),
             help='The base path for all test results (default: --build-base)')
         group = parser.add_mutually_exclusive_group()
         group.add_argument(


### PR DESCRIPTION
This change enhances the behavior of command line arguments which specify a path which might be relative to the current directory.

The new functionality captures the current working directory when the parser is constructed, and captures a given relative path on the command line by resolving it from that captured working directory. If an argument is left to the default value, it is not resolved by this new functionality and is left for resolution in the consuming code later.

The main use case for this capture-then-resolve behavior is to support changing the working directory of the colcon process. If that happens, the context of where a user intended a relative path to be based is lost, so this change captures the directory early in the colcon startup sequence.

An alternative approach to changing resolving the path only when specified on the command line could involve creating a custom argparse action implementation. A disadvantage would be a tighter coupling to the argparse API.