### PR TITLE
Add markers to linter tests, move linter imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,9 @@ filterwarnings =
     # Suppress resource warnings pending investigation
     always::ResourceWarning
 junit_suite_name = colcon-core
+markers =
+    flake8
+    linter
 python_classes = !TestFailure
 
 [options.entry_points]

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -53,6 +53,7 @@ junit
 levelname
 libexec
 lineno
+linter
 linux
 lstrip
 mkdtemp

--- a/test/test_copyright_license.py
+++ b/test/test_copyright_license.py
@@ -4,7 +4,10 @@
 from pathlib import Path
 import sys
 
+import pytest
 
+
+@pytest.mark.linter
 def test_copyright_license():
     missing = check_files([
         Path(__file__).parents[1],

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -5,19 +5,20 @@ import logging
 from pathlib import Path
 import sys
 
-from flake8 import LOG
-from flake8.api.legacy import get_style_guide
-from pydocstyle.utils import log
+import pytest
 
 
-# avoid debug / info / warning messages from flake8 internals
-LOG.setLevel(logging.ERROR)
-
-
+@pytest.mark.flake8
+@pytest.mark.linter
 def test_flake8():
+    from flake8.api.legacy import get_style_guide
+
+    # avoid debug / info / warning messages from flake8 internals
+    logging.getLogger('flake8').setLevel(logging.ERROR)
+
     # for some reason the pydocstyle logger changes to an effective level of 1
     # set higher level to prevent the output to be flooded with debug messages
-    log.setLevel(logging.WARNING)
+    logging.getLogger('pydocstyle').setLevel(logging.WARNING)
 
     style_guide = get_style_guide(
         extend_ignore=['D100', 'D104'],

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -4,10 +4,6 @@
 from pathlib import Path
 
 import pytest
-from scspell import Report
-from scspell import SCSPELL_BUILTIN_DICT
-from scspell import spell_check
-
 
 spell_check_words_path = Path(__file__).parent / 'spell_check.words'
 
@@ -18,7 +14,12 @@ def known_words():
     return spell_check_words_path.read_text().splitlines()
 
 
+@pytest.mark.linter
 def test_spell_check(known_words):
+    from scspell import Report
+    from scspell import SCSPELL_BUILTIN_DICT
+    from scspell import spell_check
+
     source_filenames = [
         Path(__file__).parents[1] / 'bin' / 'colcon',
         Path(__file__).parents[1] / 'setup.py'] + \
@@ -46,11 +47,13 @@ def test_spell_check(known_words):
         ', '.join(sorted(unused_known_words))
 
 
+@pytest.mark.linter
 def test_spell_check_word_list_order(known_words):
     assert known_words == sorted(known_words), \
         'The word list should be ordered alphabetically'
 
 
+@pytest.mark.linter
 def test_spell_check_word_list_duplicates(known_words):
     assert len(known_words) == len(set(known_words)), \
         'The word list should not contain duplicates'


### PR DESCRIPTION
Test markers can be used to easily (de-)select tests, and colcon exposes mechanisms to do so. Linters are a category of tests that are commonly called out.

Additionally, if we move the imports for some of our single-purpose tests into the test function, we can avoid installing the linter dependencies entirely. This is a common case in platform packaging, where linter errors are not actionable and the dependencies are not typically installed.

When this change is merged here, I'll make the same change in the extension template package and eventually other colcon packages.