### PR TITLE
Remove setup.py link after successful _undo_develop

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -198,6 +198,8 @@ class PythonBuildTask(TaskExtensionPoint):
             ]
             completed = await run(
                 self.context, cmd, cwd=args.build_base, env=env)
+            if not completed.returncode:
+                os.remove(setup_py_build_space)
             return completed.returncode
 
     def _undo_install(self, pkg, args, setup_py_data, python_lib):


### PR DESCRIPTION
This function reverts a previous setuptools 'develop' operation, but doesn't actually clean up the artifacts under the build tree that it used to determine that 'develop' was previously used. The result is that after performing a build with --symlink-install, all subsequent builds of that package without --symlink-install will run the commands to "undo" the develop operation even if there is nothing to undo.

This should provide a small performance improvement under those specific circumstances.