### PR TITLE
Don't pass COV_CORE_SOURCE to python build subprocess

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -76,6 +76,8 @@ class PythonBuildTask(TaskExtensionPoint):
         env = dict(env)
         env['PYTHONPATH'] = str(prefix_override) + os.pathsep + \
             python_lib + os.pathsep + env.get('PYTHONPATH', '')
+        # coverage capture interferes with sitecustomize
+        env.pop('COV_CORE_SOURCE', None)
 
         # determine if setuptools specific commands are available
         available_commands = await self._get_available_commands(

--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -77,6 +77,8 @@ class PythonBuildTask(TaskExtensionPoint):
         env['PYTHONPATH'] = str(prefix_override) + os.pathsep + \
             python_lib + os.pathsep + env.get('PYTHONPATH', '')
         # coverage capture interferes with sitecustomize
+        # See also: https://docs.python.org/3/library/site.html#module-site
+        # See also: colcon/colcon-core#579
         env.pop('COV_CORE_SOURCE', None)
 
         # determine if setuptools specific commands are available


### PR DESCRIPTION
It appears that when this varible is set, pytest-cov will import modules during the interpreter initialization before the sitecustomize hook runs. Among the modules imported is sysconfig, which caches its global state before we're able to modify it, thus rendering the entire hook unusable.

The documentation for the 'site' module has more details here, but I wasn't able to find a more aggressive way to prioritize our hook over others. For now, we should suppress COV_CORE_SOURCE to unblock new tests in colcon itself.