### PR TITLE
Drop ResourceWarning suppression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,8 +74,6 @@ filterwarnings =
     ignore:The loop argument is deprecated::asyncio
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pydocstyle
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pyreadline
-    # Suppress resource warnings pending investigation
-    always::ResourceWarning
 junit_suite_name = colcon-core
 markers =
     flake8


### PR DESCRIPTION
This suppression is no longer necessary after the fix introduced as part of #573.