### PR TITLE
Fix compatibility with Python < 3.10 importlib.metadata

### DIFF
--- a/colcon_core/extension_point.py
+++ b/colcon_core/extension_point.py
@@ -53,9 +53,10 @@ def get_all_extension_points():
     entry_points = defaultdict(dict)
     seen = set()
     for dist in distributions():
-        if dist.name in seen:
+        dist_name = dist.metadata['Name']
+        if dist_name in seen:
             continue
-        seen.add(dist.name)
+        seen.add(dist_name)
         for entry_point in dist.entry_points:
             # skip groups which are not registered as extension points
             if entry_point.group not in colcon_extension_points:
@@ -69,7 +70,7 @@ def get_all_extension_points():
                     f"from '{dist._path}' "
                     f"overwriting '{previous}'")
             entry_points[entry_point.group][entry_point.name] = \
-                (entry_point.value, dist.name, dist.version)
+                (entry_point.value, dist_name, dist.version)
     return entry_points
 
 

--- a/test/test_extension_point.py
+++ b/test/test_extension_point.py
@@ -28,12 +28,16 @@ class Dist():
     version = '0.0.0'
 
     def __init__(self, entry_points):
-        self.name = f'dist-{id(self)}'
+        self.metadata = {'Name': f'dist-{id(self)}'}
         self._entry_points = entry_points
 
     @property
     def entry_points(self):
         return list(self._entry_points)
+
+    @property
+    def name(self):
+        return self.metadata['Name']
 
 
 def iter_entry_points(*, group=None):


### PR DESCRIPTION
It appears that the Distribution.name property was introduced in Python 3.10.

It would have been nice if CI would have caught this before I tagged the release.

Fixes #562