### PR TITLE
Revert from using importlib.metadata back to pkg_resources

### DIFF
--- a/colcon_core/package_identification/python.py
+++ b/colcon_core/package_identification/python.py
@@ -90,17 +90,11 @@ def get_configuration(setup_cfg):
         except ImportError:
             from setuptools.config import read_configuration
     except ImportError as e:
-        try:
-            from importlib.metadata import distribution
-        except ImportError:
-            from importlib_metadata import distribution
-        from packaging.version import Version
-        try:
-            setuptools_version = distribution('setuptools').version
-        except ModuleNotFoundError:
-            setuptools_version = '0'
+        from pkg_resources import get_distribution
+        from pkg_resources import parse_version
+        setuptools_version = get_distribution('setuptools').version
         minimum_version = '30.3.0'
-        if Version(setuptools_version) < Version(minimum_version):
+        if parse_version(setuptools_version) < parse_version(minimum_version):
             e.msg += ', ' \
                 "'setuptools' needs to be at least version " \
                 f'{minimum_version}, if a newer version is not available ' \

--- a/colcon_core/plugin_system.py
+++ b/colcon_core/plugin_system.py
@@ -6,7 +6,7 @@ import traceback
 
 from colcon_core.extension_point import load_extension_points
 from colcon_core.logging import colcon_logger
-from packaging.version import Version
+from pkg_resources import parse_version
 
 logger = colcon_logger.getChild(__name__)
 
@@ -166,8 +166,8 @@ def satisfies_version(version, caret_range):
     :raises RuntimeError: if the version doesn't match the caret range
     """
     assert caret_range.startswith('^'), 'Only supports caret ranges'
-    extension_point_version = Version(version)
-    extension_version = Version(caret_range[1:])
+    extension_point_version = parse_version(version)
+    extension_version = parse_version(caret_range[1:])
     next_extension_version = _get_upper_bound_caret_version(
         extension_version)
 
@@ -192,4 +192,4 @@ def _get_upper_bound_caret_version(version):
         minor = 0
     else:
         minor += 1
-    return Version('%d.%d.0' % (major, minor))
+    return parse_version('%d.%d.0' % (major, minor))

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -13,7 +13,7 @@ from colcon_core.task import run
 from colcon_core.task.python.test import has_test_dependency
 from colcon_core.task.python.test import PythonTestingStepExtensionPoint
 from colcon_core.verb.test import logger
-from packaging.version import Version
+from pkg_resources import parse_version
 
 
 class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
@@ -64,7 +64,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
         # use -o option only when available
         # https://github.com/pytest-dev/pytest/blob/3.3.0/CHANGELOG.rst
         from pytest import __version__ as pytest_version
-        if Version(pytest_version) >= Version('3.3.0'):
+        if parse_version(pytest_version) >= parse_version('3.3.0'):
             args += [
                 '-o', 'cache_dir=' + str(PurePosixPath(
                     *(Path(context.args.build_base).parts)) / '.pytest_cache'),
@@ -95,7 +95,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
                 ]
                 # use --cov-branch option only when available
                 # https://github.com/pytest-dev/pytest-cov/blob/v2.5.0/CHANGELOG.rst
-                if Version(pytest_cov_version) >= Version('2.5.0'):
+                if parse_version(pytest_cov_version) >= parse_version('2.5.0'):
                     args += [
                         '--cov-branch',
                     ]

--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -5,9 +5,9 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 
 --- setup.cfg	2018-05-27 11:22:33.000000000 -0700
 +++ setup.cfg.patched	2018-05-27 11:22:33.000000000 -0700
-@@ -33,9 +33,12 @@
- 	importlib-metadata; python_version < "3.8"
- 	packaging
+@@ -31,9 +31,12 @@
+ 	distlib
+ 	EmPy
  	pytest
 -	pytest-cov
 -	pytest-repeat

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,6 @@ install_requires =
   coloredlogs; sys_platform == 'win32'
   distlib
   EmPy
-  importlib-metadata; python_version < "3.8"
-  packaging
   # the pytest dependency and its extensions are provided for convenience
   # even though they are only conditional
   pytest
@@ -69,7 +67,7 @@ filterwarnings =
     error
     # Suppress deprecation warnings in other packages
     ignore:lib2to3 package is deprecated::scspell
-    ignore:pkg_resources is deprecated as an API::colcon_core.entry_point
+    ignore:pkg_resources is deprecated as an API
     ignore:SelectableGroups dict interface is deprecated::flake8
     ignore:The loop argument is deprecated::asyncio
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pydocstyle

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-core]
 No-Python2:
-Depends3: python3-distlib, python3-empy, python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata
+Depends3: python3-distlib, python3-empy, python3-packaging, python3-pytest, python3-setuptools
 Recommends3: python3-pytest-cov
 Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
 Suite: bionic focal jammy stretch buster bullseye

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ addopts
 apache
 argparse
 asyncio
+attrs
 autouse
 basepath
 bazqux
@@ -46,7 +47,6 @@ hardcodes
 hookimpl
 hookwrapper
 https
-importlib
 isatty
 iterdir
 junit

--- a/test/test_extension_point.py
+++ b/test/test_extension_point.py
@@ -17,100 +17,96 @@ import pytest
 from .environment_context import EnvironmentContext
 
 
-Group1 = EntryPoint('group1', 'g1', EXTENSION_POINT_GROUP_NAME)
-Group2 = EntryPoint('group2', 'g2', EXTENSION_POINT_GROUP_NAME)
-ExtA = EntryPoint('extA', 'eA', Group1.name)
-ExtB = EntryPoint('extB', 'eB', Group1.name)
+Group1 = EntryPoint('group1', 'g1')
+Group2 = EntryPoint('group2', 'g2')
 
 
 class Dist():
 
-    version = '0.0.0'
+    project_name = 'dist'
 
-    def __init__(self, entry_points):
-        self.metadata = {'Name': f'dist-{id(self)}'}
-        self._entry_points = entry_points
+    def __init__(self, group_name, group):
+        self._group_name = group_name
+        self._group = group
 
-    @property
-    def entry_points(self):
-        return list(self._entry_points)
+    def __lt__(self, other):
+        return self._group_name < other._group_name
 
-    @property
-    def name(self):
-        return self.metadata['Name']
+    def get_entry_map(self):
+        return self._group
 
 
-def iter_entry_points(*, group=None):
+def iter_entry_points(*, group):
     if group == EXTENSION_POINT_GROUP_NAME:
         return [Group1, Group2]
-    elif group == Group1.name:
-        return [ExtA, ExtB]
-    assert not group
-    return {
-        EXTENSION_POINT_GROUP_NAME: [Group1, Group2],
-        Group1.name: [ExtA, ExtB],
-    }
+    assert group == Group1.name
+    ep1 = EntryPoint('extA', 'eA')
+    ep2 = EntryPoint('extB', 'eB')
+    return [ep1, ep2]
 
 
-def distributions():
+def working_set():
     return [
-        Dist(iter_entry_points(group='group1')),
-        Dist([EntryPoint('extC', 'eC', Group2.name)]),
-        Dist([EntryPoint('extD', 'eD', 'groupX')]),
+        Dist('group1', {
+            'group1': {ep.name: ep for ep in iter_entry_points(group='group1')}
+        }),
+        Dist('group2', {'group2': {'extC': EntryPoint('extC', 'eC')}}),
+        Dist('groupX', {'groupX': {'extD': EntryPoint('extD', 'eD')}}),
     ]
 
 
 def test_all_extension_points():
     with patch(
-        'colcon_core.extension_point.entry_points',
+        'colcon_core.extension_point.iter_entry_points',
         side_effect=iter_entry_points
     ):
         with patch(
-            'colcon_core.extension_point.distributions',
-            side_effect=distributions
+            'colcon_core.extension_point.WorkingSet',
+            side_effect=working_set
         ):
             # successfully load a known entry point
             extension_points = get_all_extension_points()
             assert set(extension_points.keys()) == {'group1', 'group2'}
             assert set(extension_points['group1'].keys()) == {'extA', 'extB'}
-            assert extension_points['group1']['extA'][0] == 'eA'
+            assert extension_points['group1']['extA'] == (
+                'eA', Dist.project_name, None)
 
 
 def test_extension_point_blocklist():
     # successful loading of extension point without a blocklist
     with patch(
-        'colcon_core.extension_point.entry_points',
+        'colcon_core.extension_point.iter_entry_points',
         side_effect=iter_entry_points
     ):
         with patch(
-            'colcon_core.extension_point.distributions',
-            side_effect=distributions
+            'colcon_core.extension_point.WorkingSet',
+            side_effect=working_set
         ):
             extension_points = get_extension_points('group1')
     assert 'extA' in extension_points.keys()
     extension_point = extension_points['extA']
     assert extension_point == 'eA'
 
-    with patch.object(EntryPoint, 'load', return_value=None) as load:
+    with patch.object(EntryPoint, 'resolve', return_value=None) as resolve:
         load_extension_point('extA', 'eA', 'group1')
-        assert load.call_count == 1
+        assert resolve.call_count == 1
 
         # successful loading of entry point not in blocklist
-        load.reset_mock()
+        resolve.reset_mock()
         with EnvironmentContext(COLCON_EXTENSION_BLOCKLIST=os.pathsep.join([
             'group1.extB', 'group2.extC'])
         ):
             load_extension_point('extA', 'eA', 'group1')
-        assert load.call_count == 1
+        assert resolve.call_count == 1
 
         # entry point in a blocked group can't be loaded
-        load.reset_mock()
+        resolve.reset_mock()
         with EnvironmentContext(COLCON_EXTENSION_BLOCKLIST='group1'):
             with pytest.raises(RuntimeError) as e:
                 load_extension_point('extA', 'eA', 'group1')
             assert 'The entry point group name is listed in the environment ' \
                 'variable' in str(e.value)
-        assert load.call_count == 0
+        assert resolve.call_count == 0
 
         # entry point listed in the blocklist can't be loaded
         with EnvironmentContext(COLCON_EXTENSION_BLOCKLIST=os.pathsep.join([
@@ -120,10 +116,10 @@ def test_extension_point_blocklist():
                 load_extension_point('extA', 'eA', 'group1')
             assert 'The entry point name is listed in the environment ' \
                 'variable' in str(e.value)
-        assert load.call_count == 0
+        assert resolve.call_count == 0
 
 
-def entry_point_load(self, *args, **kwargs):
+def entry_point_resolve(self, *args, **kwargs):
     if self.name == 'exception':
         raise Exception('entry point raising exception')
     if self.name == 'runtime_error':
@@ -133,7 +129,7 @@ def entry_point_load(self, *args, **kwargs):
     return DEFAULT
 
 
-@patch.object(EntryPoint, 'load', entry_point_load)
+@patch.object(EntryPoint, 'resolve', entry_point_resolve)
 @patch(
     'colcon_core.extension_point.get_extension_points',
     return_value={'exception': 'a', 'runtime_error': 'b', 'success': 'c'}


### PR DESCRIPTION
It appears that we accidentally shipped this incompatible change on Ubuntu Bionic, which is currently under ESM. While we do intend to drop mainline support for Bionic, we should leave it in a good state.

The plan is to release this change in a new version of `colcon-core` and then immediately drop `bionic` from the deb releases, revert this change, and then ship another new version of `colcon-core` which restores the current state.

This reverts #585
This reverts #562
This reverts #560