### PR TITLE
Update target platforms for debs

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -8,9 +8,7 @@ artifacts:
         config:
           repository: dirk-thomas/colcon
           distributions:
-            - ubuntu:bionic
             - ubuntu:focal
             - ubuntu:jammy
-            - debian:stretch
-            - debian:buster
             - debian:bullseye
+            - debian:bookworm

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ No-Python2:
 Depends3: python3-distlib, python3-empy, python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata
 Recommends3: python3-pytest-cov
 Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
-Suite: bionic focal jammy stretch buster bullseye
+Suite: focal jammy bullseye bookworm
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
* Bionic is in ESM and does not package importlib-metadata
* Buster does not package importlib-metadata
* Stretch has Python 3.5 and hasn't been support for a long time now
* Bookworm is the current "stable" Debian

When this change is merged into `colcon-core`, I'm going to make the same change in the other colcon packages without review, since it will effectively be a cherry-pick.