### PR TITLE
Allow invocation from sub folder and reuse build, install, log folders in workspace root

### DIFF
--- a/colcon_core/argument_type.py
+++ b/colcon_core/argument_type.py
@@ -5,6 +5,7 @@ import functools
 import os
 
 from colcon_core.argument_default import is_default_value
+from colcon_core.location import get_root_path
 
 
 def resolve_path(value, base=os.getcwd()):
@@ -17,11 +18,19 @@ def resolve_path(value, base=os.getcwd()):
     :param value: The value to resolve to an absolute path
     :returns: The unmodified value, or resolved path
     """
-    if value is None or is_default_value(value):
+    if value is None:
         return value
     res = os.path.abspath(os.path.join(base, str(value)))
     return res
 
+
+def get_root_path_resolver():
+    """
+    Create a function which resolves paths from the colcon workspace root.
+
+    :returns: A function which takes a single string and returns a string
+    """
+    return functools.partial(resolve_path, base=get_root_path())
 
 def get_cwd_path_resolver():
     """

--- a/colcon_core/argument_type.py
+++ b/colcon_core/argument_type.py
@@ -20,6 +20,8 @@ def resolve_path(value, base=os.getcwd()):
     """
     if value is None:
         return value
+    if os.path.isabs(value):
+        return value
     res = os.path.abspath(os.path.join(base, str(value)))
     return res
 

--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -54,6 +54,7 @@ from colcon_core.argument_parser import SuppressUsageOutput  # noqa: E402
 from colcon_core.extension_point import load_extension_points  # noqa: E402
 from colcon_core.location import create_log_path  # noqa: E402
 from colcon_core.location import get_log_path  # noqa: E402
+from colcon_core.location import get_root_path  # noqa: E402
 from colcon_core.location import set_default_config_path  # noqa: E402
 from colcon_core.location import set_default_log_path  # noqa: E402
 from colcon_core.logging import add_file_handler  # noqa: E402

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -10,7 +10,7 @@ import traceback
 from colcon_core.argument_default import wrap_default_value
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
-from colcon_core.argument_type import get_cwd_path_resolver
+from colcon_core.argument_type import get_root_path_resolver
 from colcon_core.event.job import JobUnselected
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.executor import add_executor_arguments
@@ -86,12 +86,12 @@ class BuildVerb(VerbExtensionPoint):
         parser.add_argument(
             '--build-base',
             default=wrap_default_value('build'),
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all build directories (default: build)')
         parser.add_argument(
             '--install-base',
             default=wrap_default_value('install'),
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all install prefixes (default: install)')
         parser.add_argument(
             '--merge-install',
@@ -103,7 +103,7 @@ class BuildVerb(VerbExtensionPoint):
             help='Use symlinks instead of copying files where possible')
         parser.add_argument(
             '--test-result-base',
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all test results (default: --build-base)')
         parser.add_argument(
             '--continue-on-error',

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -8,7 +8,7 @@ import types
 from colcon_core.argument_default import wrap_default_value
 from colcon_core.argument_parser.destination_collector \
     import DestinationCollectorDecorator
-from colcon_core.argument_type import get_cwd_path_resolver
+from colcon_core.argument_type import get_root_path_resolver
 from colcon_core.event.test import TestFailure
 from colcon_core.event_handler import add_event_handler_arguments
 from colcon_core.executor import add_executor_arguments
@@ -88,12 +88,12 @@ class TestVerb(VerbExtensionPoint):
         parser.add_argument(
             '--build-base',
             default=wrap_default_value('build'),
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all build directories (default: build)')
         parser.add_argument(
             '--install-base',
             default=wrap_default_value('install'),
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all install prefixes (default: install)')
         parser.add_argument(
             '--merge-install',
@@ -101,7 +101,7 @@ class TestVerb(VerbExtensionPoint):
             help='Merge all install prefixes into a single location')
         parser.add_argument(
             '--test-result-base',
-            type=get_cwd_path_resolver(),
+            type=get_root_path_resolver(),
             help='The base path for all test results (default: --build-base)')
         group = parser.add_mutually_exclusive_group()
         group.add_argument(


### PR DESCRIPTION
This is an attempt to resolve #139 and #369, i.e. (re)using the `build`, `install`, and `log` folders from the workspace root even when started from a subfolder.
To this end, the first commit replaces the current `get_cwd_path_resolver()` with a new `get_root_path_resolver()`, which operates relative to the workspace root.
The workspace root is identified by a `.colcon_root` marker file or guessed by the existence of the log, build, and install folders.

Additionally to that, I would like to add the possibility to pretend that colcon was run from the root folder, thus allowing to trigger a full rebuild from any subfolder.
To this end, I added a `--cd-root` option, changing the working directory before processing a verb action.
However, that doesn't work because the `get_cwd_path_resolver()`, used for package discovery, operates on the original cwd:
https://github.com/colcon/colcon-core/blob/a6aef1515b946f5af47b16d55b4f9ffaaaa27126/colcon_core/argument_type.py#L30-L32

To resolve that, I could handle the `--cd-root` option _before_ instantiating verb parsers (and thus resolver functions).  
Alternatively, I could imagine introducing a special keyword (e.g. `ROOT`) to pass to the `--base-paths` argument.

Extensions, which should also resolve w.r.t. the workspace root, need to be adapted as well:
- [x] https://github.com/colcon/colcon-test-result/pull/49
- [x] https://github.com/colcon/colcon-clean/pull/38