### PR TITLE
pin version of empy to 3.3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,9 @@ python_requires = >=3.6
 install_requires =
   coloredlogs; sys_platform == 'win32'
   distlib
-  EmPy
+  # pining empy to 3.3.4 since the release of empy 4 breaks colcon
+  # see https://github.com/colcon/colcon-core/issues/602 
+  EmPy==3.3.4 
   importlib-metadata; python_version < "3.8"
   packaging
   # the pytest dependency and its extensions are provided for convenience


### PR DESCRIPTION
### Description
Due to the new release of empy 4, CI has been broken since colcon broke with it. See: 
- https://github.com/colcon/colcon-core/issues/602 

This PR pins the dependecy to the previous working version `3.3.4` .
