### PR TITLE
Fix entry point discovery on Python < 3.10

### DIFF
--- a/test/test_extension_point.py
+++ b/test/test_extension_point.py
@@ -54,8 +54,8 @@ def iter_entry_points(*, group=None):
 
 def distributions():
     return [
-        Dist(iter_entry_points(group='group1')),
-        Dist([EntryPoint('extC', 'eC', Group2.name)]),
+        Dist([Group1, ExtA, ExtB]),
+        Dist([Group2, EntryPoint('extC', 'eC', Group2.name)]),
         Dist([EntryPoint('extD', 'eD', 'groupX')]),
     ]
 
@@ -71,7 +71,11 @@ def test_all_extension_points():
         ):
             # successfully load a known entry point
             extension_points = get_all_extension_points()
-            assert set(extension_points.keys()) == {'group1', 'group2'}
+            assert set(extension_points.keys()) == {
+                EXTENSION_POINT_GROUP_NAME,
+                'group1',
+                'group2',
+            }
             assert set(extension_points['group1'].keys()) == {'extA', 'extB'}
             assert extension_points['group1']['extA'][0] == 'eA'
 


### PR DESCRIPTION
It seems that the behavior of the `importlib.metadata.entry_points` function changed in Python 3.10 to automatically de-duplicate distributions, but prior to that the "shadowed" distributions were also enumerated. This change specifically ignores "shadowed" distributions so that they aren't identified as extension point overwrites.

Fixes #562
Closes #596
When released, will eventually close ros2/ci#737.