### PR TITLE
Use a normalized package name in Python build test

### DIFF
--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -76,7 +76,7 @@ def _test_build_package(tmp_path_str, *, symlink_install):
         (pkg.path / 'setup.py').write_text(
             'from setuptools import setup\n'
             'setup(\n'
-            '    name="test_package",\n'
+            '    name="test-package",\n'
             '    packages=["my_module"],\n'
             ')\n'
         )


### PR DESCRIPTION
It appears that newer setuptools versions are no longer normalizing the package name. Rather than update the name that we're looking for, we should just use a normalized name to begin with so that the test works with both old and newer setuptools versions.