### PR TITLE
Update setuptools deprecations AGAIN

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,8 +68,9 @@ exclude =
 filterwarnings =
     error
     # Suppress deprecation warnings in other packages
+    ignore:Deprecated call to `pkg_resources.declare_namespace\('paste'\)`::
     ignore:lib2to3 package is deprecated::scspell
-    ignore:pkg_resources is deprecated as an API::colcon_core.entry_point
+    ignore:pkg_resources is deprecated as an API::
     ignore:SelectableGroups dict interface is deprecated::flake8
     ignore:The loop argument is deprecated::asyncio
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pydocstyle


### PR DESCRIPTION
It seems that setuptools has made changes which require us to update our deprecation warning suppression. I think it actually changed twice: once that regressed the stacklevel for the warning, and another time which changed the message entirely.

TIL that suppressing setuptools warnings is akin to whack-a-mole.

In addition to CI, I tested this with setuptools `69.0.3` and `67.7.2`.