### PR TITLE
Add support for flake8 v6

### DIFF
--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -244,7 +244,7 @@ def add_executor_arguments(parser):
     group.add_argument(
         '--executor', type=str, choices=keys, default=default,
         help=f'The executor to process all packages (default: {default})'
-             f'{descriptions}')
+             f'{descriptions}')  # noqa: E131
 
     for priority in extensions.keys():
         extensions_same_prio = extensions[priority]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ zip_safe = false
 
 [options.extras_require]
 test =
-  flake8>=3.6.0,<6
+  flake8>=3.6.0,<7
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
It seems that flake8 v6 started checking indentation of multi-line string literals, but it doesn't seem to work correctly for f-strings.

Originally pinned in #537.