### PR TITLE
Don't write bytecode when invoking Python tests

### DIFF
--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -73,6 +73,9 @@ class PythonTestTask(TaskExtensionPoint):
 
         logger.log(1, f"test.step() by extension '{key}'")
         try:
+            if 'PYTHONDONTWRITEBYTECODE' not in env:
+                env = dict(env)
+                env['PYTHONDONTWRITEBYTECODE'] = '1'
             return await extension.step(self.context, env, setup_py_data)
         except Exception as e:  # noqa: F841
             # catch exceptions raised in python testing step extension

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -79,6 +79,7 @@ purelib
 pydocstyle
 pytest
 pytests
+pythondontwritebytecode
 pythonpath
 pythonscriptspath
 pythonwarnings


### PR DESCRIPTION
This should help to avoid writing compiled bytecode into the source directories of Python packages during test invocation.

https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE