### PR TITLE
Refactor python build test to improve coverage

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -47,6 +47,7 @@ hookimpl
 hookwrapper
 https
 importlib
+importorskip
 isatty
 iterdir
 junit
@@ -56,6 +57,7 @@ lineno
 linter
 linux
 lstrip
+minversion
 mkdtemp
 monkeypatch
 namedtuple


### PR DESCRIPTION
Switching to a parametrized approach also significantly reduces duplicated code in the test.