### PR TITLE
Add an explicit cache on Python entry points

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -50,6 +50,7 @@ importlib
 importorskip
 isatty
 iterdir
+itertools
 junit
 levelname
 libexec


### PR DESCRIPTION
Whenever we enumerate Python entry points to load colcon extension points, we're re-parsing metadata for every Python package found on the system. Worse yet, accessing attributes on importlib.metadata.Distribution typically results in re-reading the metadata each time, so we're hitting the disk pretty hard.

We don't generally expect the entry points available to change, so we should cache that information once and parse each package's metadata a single time.

Closes #600