### PR TITLE
Allow use of flake8 v7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ zip_safe = false
 
 [options.extras_require]
 test =
-  flake8>=3.6.0,<7
+  flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
   flake8-class-newline


### PR DESCRIPTION
All packages in the colcon org appear to test successfully against flake8 v7 now.