### PR TITLE
Drop superfluous 'global' statements from command.py

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -86,7 +86,6 @@ def register_command_exit_handler(handler):
 
     :param handler: The callable
     """
-    global _command_exit_handlers
     if handler not in _command_exit_handlers:
         _command_exit_handlers.append(handler)
 
@@ -113,7 +112,6 @@ def main(*, command_name='colcon', argv=None):
     :param list argv: The list of arguments
     :returns: The return code
     """
-    global _command_exit_handlers
     try:
         return _main(command_name=command_name, argv=argv)
     except KeyboardInterrupt:
@@ -126,7 +124,6 @@ def main(*, command_name='colcon', argv=None):
 
 
 def _main(*, command_name, argv):
-    global colcon_logger
     # default log level, for searchability: COLCON_LOG_LEVEL
     colcon_logger.setLevel(logging.WARNING)
     set_logger_level_from_env(
@@ -375,7 +372,6 @@ def create_subparser(parser, cmd_name, verb_extensions, *, attribute):
       selected verb
     :returns: The special action object
     """
-    global colcon_logger
     assert verb_extensions, 'No verb extensions'
 
     # list of available verbs with their descriptions


### PR DESCRIPTION
I don't see any reason that these statements should be necessary and find their presence confusing.

I'd love to hear feedback either way from any Pythonistas out there who might have some idea why these were added to begin with.