### PR TITLE
Suppress setup.py deprecation warnings during build

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -8,7 +8,6 @@ import os
 from pathlib import Path
 import shutil
 import sys
-from sys import executable
 
 from colcon_core.environment import create_environment_hooks
 from colcon_core.environment import create_environment_scripts
@@ -25,6 +24,12 @@ from colcon_core.task.python import get_setup_data
 from colcon_core.task.python.template import expand_template
 
 logger = colcon_logger.getChild(__name__)
+
+_PYTHON_CMD = [
+    sys.executable,
+    '-W',
+    'ignore:setup.py install is deprecated',
+]
 
 
 def _get_install_scripts(path):
@@ -92,7 +97,7 @@ class PythonBuildTask(TaskExtensionPoint):
 
             # invoke `setup.py install` step with lots of arguments
             # to avoid placing any files in the source space
-            cmd = [executable, 'setup.py']
+            cmd = _PYTHON_CMD + ['setup.py']
             if 'egg_info' in available_commands:
                 # `setup.py egg_info` requires the --egg-base to exist
                 os.makedirs(args.build_base, exist_ok=True)
@@ -139,8 +144,8 @@ class PythonBuildTask(TaskExtensionPoint):
             try:
                 # --editable causes this to skip creating/editing the
                 # easy-install.pth file
-                cmd = [
-                    executable, 'setup.py',
+                cmd = _PYTHON_CMD + [
+                    'setup.py',
                     'develop',
                     '--editable',
                     '--build-directory',
@@ -181,7 +186,7 @@ class PythonBuildTask(TaskExtensionPoint):
 
     async def _get_available_commands(self, path, env):
         output = await check_output(
-            [executable, 'setup.py', '--help-commands'], cwd=path, env=env)
+            _PYTHON_CMD + ['setup.py', '--help-commands'], cwd=path, env=env)
         commands = set()
         for line in output.splitlines():
             if not line.startswith(b'  '):
@@ -208,8 +213,8 @@ class PythonBuildTask(TaskExtensionPoint):
             args.build_base, '%s.egg-info' % pkg.name.replace('-', '_'))
         setup_py_build_space = os.path.join(args.build_base, 'setup.py')
         if os.path.exists(egg_info) and os.path.islink(setup_py_build_space):
-            cmd = [
-                executable, 'setup.py',
+            cmd = _PYTHON_CMD + [
+                'setup.py',
                 'develop',
                 '--uninstall', '--editable',
                 '--build-directory', os.path.join(args.build_base, 'build')


### PR DESCRIPTION
This warning is legitimate and something that developers should be aware of, but at present, the replacement does not provide all of the functionality necessary to support the currently available features in colcon.

When that changes, we'll communicate the upgrade path to users and re-enable the deprecation warning.

Related to #454, #208