### PR TITLE
Add Debian 'Replaces: colcon' field

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,6 @@ No-Python2:
 Depends3: python3-distlib, python3-empy (<4), python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata
 Recommends3: python3-pytest-cov
 Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
+Replaces3: colcon
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Upstream Debian has decided to package colcon, and they created a package simply called 'colcon' which provides only the `/usr/bin/colcon` executable and some weak dependencies as a sort of replacement for `colcon-common-extensions`. This conflicts with our `python3-colcon-core` package during unpacking.

We could add `Conflicts: colcon`, but I think this is a great use case for `Replaces:` because the only file provided by `colcon` is `/usr/bin/colcon`, which we obviously provide here. This way, folks can still successfully install `colcon` and get the weak dependencies even if our version of `python3-colcon-core` is installed, and our copy of `/usr/bin/colcon` will take precedence over the one provided by `colcon`.

https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces