### PR TITLE
Fixed ros2 python install using virtualenv

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -40,8 +40,11 @@ def _get_install_scripts(path):
     parser.optionxform = str
     with open(setup_cfg_path, encoding='utf-8') as f:
         parser.read_file(f)
-    return parser.get('install', 'install-scripts', fallback=None)
-
+        
+    install_script = parser.get('install', 'install_scripts', fallback=None)
+    if install_script is None:
+        install_script = parser.get('install', 'install-scripts', fallback=None)
+    return install_script
 
 class PythonBuildTask(TaskExtensionPoint):
     """Build Python packages."""


### PR DESCRIPTION
Fixed ros2 python install using virtualenv when installing a custom version from source caused by 'install_scrips' vs 'install-scripts'  entry in projects setup.cfg.