### PR TITLE
Fix argument parsing in newer Python.

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -232,7 +232,8 @@ def create_parser(environment_variables_group_name):
             # backported to Python 3.12), it returns a 4-tuple.  Check for
             # either here.
             if result in (
-                (None, arg_string, None), (None, arg_string, None, None)
+                (None, arg_string, None),
+                (None, arg_string, None, None),
             ):
                 # in the case there the arg is classified as an unknown 'O'
                 # override that and classify it as an 'A'

--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -226,7 +226,14 @@ def create_parser(environment_variables_group_name):
 
         def _parse_optional(self, arg_string):
             result = super()._parse_optional(arg_string)
-            if result == (None, arg_string, None):
+            # Up until https://github.com/python/cpython/pull/114180 ,
+            # _parse_optional() returned a 3-tuple when it couldn't classify
+            # the option.  As of that PR (which is in Python 3.13, and
+            # backported to Python 3.12), it returns a 4-tuple.  Check for
+            # either here.
+            if result in (
+                (None, arg_string, None), (None, arg_string, None, None)
+            ):
                 # in the case there the arg is classified as an unknown 'O'
                 # override that and classify it as an 'A'
                 return None

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -3,6 +3,7 @@ apache
 argparse
 asyncio
 autouse
+backported
 basepath
 bazqux
 blocklist
@@ -17,6 +18,7 @@ configparser
 contextlib
 coroutine
 coroutines
+cpython
 datetime
 debian
 debinfo


### PR DESCRIPTION
The comment in the code has more details, but as of https://github.com/python/cpython/pull/114180 we need to check for both a 3-tuple and a 4-tuple.