### PR TITLE
Suppress flake8 A005 in existing colcon API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -156,6 +156,10 @@ colcon_core.task.python.template = *.em
 
 [flake8]
 import-order-style = google
+per-file-ignores =
+    colcon_core/distutils/__init__.py:A005
+    colcon_core/logging.py:A005
+    colcon_core/subprocess.py:A005
 
 [coverage:run]
 source = colcon_core


### PR DESCRIPTION
Rather than suppress A005 completely, we can ignore it in our existing API to prevent new A005 violations from appearing.

I couldn't find a good way to suppress only A005 in the files themselves.