### PR TITLE
Make distutils symlink_data command private

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -77,9 +77,12 @@ class PythonBuildTask(TaskExtensionPoint):
         python_lib = os.path.join(
             args.install_base, self._get_python_lib(args))
         os.makedirs(python_lib, exist_ok=True)
+        distutils_commands = os.path.join(
+            os.path.dirname(__file__), 'colcon_distutils_commands')
         # and being in the PYTHONPATH
         env = dict(env)
         env['PYTHONPATH'] = str(prefix_override) + os.pathsep + \
+            distutils_commands + os.pathsep + \
             python_lib + os.pathsep + env.get('PYTHONPATH', '')
         # coverage capture interferes with sitecustomize
         # See also: https://docs.python.org/3/library/site.html#module-site

--- a/colcon_core/task/python/colcon_distutils_commands/colcon_distutils_commands-0.0.0.dist-info/METADATA
+++ b/colcon_core/task/python/colcon_distutils_commands/colcon_distutils_commands-0.0.0.dist-info/METADATA
@@ -1,0 +1,3 @@
+Metadata-Version: 2.1
+Name: colcon_distutils_commands
+Version: 0.0.0

--- a/colcon_core/task/python/colcon_distutils_commands/colcon_distutils_commands-0.0.0.dist-info/entry_points.txt
+++ b/colcon_core/task/python/colcon_distutils_commands/colcon_distutils_commands-0.0.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[distutils.commands]
+symlink_data = colcon_core.distutils.commands.symlink_data:symlink_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,14 +145,15 @@ colcon_core.verb =
     test = colcon_core.verb.test:TestVerb
 console_scripts =
     colcon = colcon_core.command:main
-distutils.commands =
-    symlink_data = colcon_core.distutils.commands.symlink_data:symlink_data
 pytest11 =
     colcon_core_warnings_stderr = colcon_core.pytest.hooks
 
 [options.package_data]
 colcon_core.shell.template = *.em
 colcon_core.task.python.template = *.em
+colcon_core.task.python.colcon_distutils_commands =
+    */METADATA
+    */entry_points.txt
 
 [flake8]
 import-order-style = google


### PR DESCRIPTION
We don't want anyone taking a dependency on this functionality, and we don't want to interfere with non-colcon use of setuptools or distutils, so it's best to just hide this entry point and make it available only when we're running our builds.