### PR TITLE
Support complex recursive dependency category specification

### DIFF
--- a/colcon_core/package_decorator.py
+++ b/colcon_core/package_decorator.py
@@ -46,8 +46,9 @@ def add_recursive_dependencies(
 
     :param set decorators: The known packages to consider
     :param Iterable[str] direct_categories: The names of the direct categories
-    :param Iterable[str] recursive_categories: The names of the recursive
-    categories
+    :param Iterable[str]|Mapping[str, Iterable[str]] recursive_categories:
+      The names of the recursive categories, optionally mapped from the
+      immediate upstream category which included the dependency
     """
     descriptors = [decorator.descriptor for decorator in decorators]
     for decorator in decorators:

--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -136,8 +136,9 @@ def get_packages(
     :param additional_argument_names: A list of additional arguments to
       consider
     :param Iterable[str] direct_categories: The names of the direct categories
-    :param Iterable[str] recursive_categories: The names of the recursive
-      categories
+    :param Iterable[str]|Mapping[str, Iterable[str]] recursive_categories:
+      The names of the recursive categories, optionally mapped from the
+      immediate upstream category which included the dependency
     :rtype: list
     :raises RuntimeError: if the returned set of packages contains duplicates
       package names


### PR DESCRIPTION
When computing the dependency graph, the existing API exposes a parameter for indicating which direct dependency categories to collect as well as what indirect (recursive) dependency categories to collect.

This change allows the caller to specify different recursive dependency categories depending on which category included the dependency in the graph to begin with.

Eventually, this enhancement can be leveraged as part of the "dependency narrowing" effort to drop build-only dependencies from a chain where only runtime dependencies are specified.