### PR TITLE
Support alternate group names in get_*_extensions

### DIFF
--- a/colcon_core/argument_parser/__init__.py
+++ b/colcon_core/argument_parser/__init__.py
@@ -42,7 +42,7 @@ class ArgumentParserDecoratorExtensionPoint:
         raise NotImplementedError()
 
 
-def get_argument_parser_extensions():
+def get_argument_parser_extensions(*, group_name=__name__):
     """
     Get the available argument parser extensions.
 
@@ -50,7 +50,7 @@ def get_argument_parser_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.ARGUMENT_PARSER_DECORATOR_NAME = name
     return order_extensions_by_priority(extensions)

--- a/colcon_core/environment/__init__.py
+++ b/colcon_core/environment/__init__.py
@@ -47,7 +47,7 @@ class EnvironmentExtensionPoint:
         raise NotImplementedError()
 
 
-def get_environment_extensions():
+def get_environment_extensions(*, group_name=__name__):
     """
     Get the available environment extensions.
 
@@ -55,7 +55,7 @@ def get_environment_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name in list(extensions.keys()):
         extension = extensions[name]
         extension.ENVIRONMENT_NAME = name

--- a/colcon_core/event_handler/__init__.py
+++ b/colcon_core/event_handler/__init__.py
@@ -44,7 +44,7 @@ class EventHandlerExtensionPoint:
         raise NotImplementedError()
 
 
-def get_event_handler_extensions(*, context):
+def get_event_handler_extensions(*, context, group_name=__name__):
     """
     Get the available event handler extensions.
 
@@ -52,7 +52,7 @@ def get_event_handler_extensions(*, context):
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.EVENT_HANDLER_NAME = name
         extension.context = context

--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -197,7 +197,7 @@ class ExecutorExtensionPoint:
         self._event_controller.flush()
 
 
-def get_executor_extensions():
+def get_executor_extensions(*, group_name=__name__):
     """
     Get the available executor extensions.
 
@@ -206,7 +206,7 @@ def get_executor_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.EXECUTOR_NAME = name
     return order_extensions_grouped_by_priority(extensions)

--- a/colcon_core/package_augmentation/__init__.py
+++ b/colcon_core/package_augmentation/__init__.py
@@ -65,7 +65,7 @@ class PackageAugmentationExtensionPoint:
         raise NotImplementedError()
 
 
-def get_package_augmentation_extensions():
+def get_package_augmentation_extensions(*, group_name=__name__):
     """
     Get the available package augmentation extensions.
 
@@ -73,7 +73,7 @@ def get_package_augmentation_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.PACKAGE_AUGMENTATION_NAME = name
     return order_extensions_by_priority(extensions)

--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -84,7 +84,7 @@ class PackageDiscoveryExtensionPoint:
         raise NotImplementedError()
 
 
-def get_package_discovery_extensions():
+def get_package_discovery_extensions(*, group_name=__name__):
     """
     Get the available package discovery extensions.
 
@@ -92,7 +92,7 @@ def get_package_discovery_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.PACKAGE_DISCOVERY_NAME = name
     return order_extensions_by_priority(extensions)

--- a/colcon_core/package_identification/__init__.py
+++ b/colcon_core/package_identification/__init__.py
@@ -64,7 +64,7 @@ class PackageIdentificationExtensionPoint:
         raise NotImplementedError()
 
 
-def get_package_identification_extensions():
+def get_package_identification_extensions(*, group_name=__name__):
     """
     Get the available package identification extensions.
 
@@ -73,7 +73,7 @@ def get_package_identification_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.PACKAGE_IDENTIFICATION_NAME = name
     return order_extensions_grouped_by_priority(extensions)

--- a/colcon_core/package_selection/__init__.py
+++ b/colcon_core/package_selection/__init__.py
@@ -85,7 +85,7 @@ def add_arguments(parser):
     _add_package_selection_arguments(parser)
 
 
-def get_package_selection_extensions():
+def get_package_selection_extensions(*, group_name=__name__):
     """
     Get the available package selection extensions.
 
@@ -93,7 +93,7 @@ def get_package_selection_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.PACKAGE_SELECTION_NAME = name
     return order_extensions_by_priority(extensions)

--- a/colcon_core/prefix_path/__init__.py
+++ b/colcon_core/prefix_path/__init__.py
@@ -40,7 +40,7 @@ class PrefixPathExtensionPoint:
         raise NotImplementedError()
 
 
-def get_prefix_path_extensions():
+def get_prefix_path_extensions(*, group_name=__name__):
     """
     Get the available prefix path extensions.
 
@@ -49,7 +49,7 @@ def get_prefix_path_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.PREFIX_PATH_NAME = name
     return order_extensions_grouped_by_priority(extensions)

--- a/colcon_core/shell/__init__.py
+++ b/colcon_core/shell/__init__.py
@@ -273,7 +273,7 @@ class ShellExtensionPoint:
         raise NotImplementedError()
 
 
-def get_shell_extensions():
+def get_shell_extensions(*, group_name=__name__):
     """
     Get the available shell extensions.
 
@@ -282,7 +282,7 @@ def get_shell_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.SHELL_NAME = name
     return order_extensions_grouped_by_priority(extensions)
@@ -593,7 +593,7 @@ class FindInstalledPackagesExtensionPoint:
         raise NotImplementedError()
 
 
-def get_find_installed_packages_extensions():
+def get_find_installed_packages_extensions(*, group_name=__name__):
     """
     Get the available package identification extensions.
 
@@ -602,7 +602,8 @@ def get_find_installed_packages_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__ + '.find_installed_packages')
+    extensions = instantiate_extensions(
+        group_name + '.find_installed_packages')
     for name, extension in extensions.items():
         extension.PACKAGE_IDENTIFICATION_NAME = name
     return order_extensions_grouped_by_priority(extensions)

--- a/colcon_core/task/python/test/__init__.py
+++ b/colcon_core/task/python/test/__init__.py
@@ -137,7 +137,9 @@ class PythonTestingStepExtensionPoint:
         raise NotImplementedError()
 
 
-def get_python_testing_step_extensions():
+def get_python_testing_step_extensions(
+    *, group_name='colcon_core.python_testing',
+):
     """
     Get the available Python testing step extensions.
 
@@ -145,8 +147,7 @@ def get_python_testing_step_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(
-        'colcon_core.python_testing', unique_instance=False)
+    extensions = instantiate_extensions(group_name, unique_instance=False)
     for name in list(extensions.keys()):
         extension = extensions[name]
         extension.STEP_TYPE = name

--- a/colcon_core/verb/__init__.py
+++ b/colcon_core/verb/__init__.py
@@ -48,7 +48,7 @@ class VerbExtensionPoint:
         raise NotImplementedError()
 
 
-def get_verb_extensions():
+def get_verb_extensions(*, group_name=__name__):
     """
     Get the available verb extensions.
 
@@ -56,7 +56,7 @@ def get_verb_extensions():
 
     :rtype: OrderedDict
     """
-    extensions = instantiate_extensions(__name__)
+    extensions = instantiate_extensions(group_name)
     for name, extension in extensions.items():
         extension.VERB_NAME = name
     return order_extensions_by_name(extensions)


### PR DESCRIPTION
These functions are brief, but it would be nice not to have to duplicate them in other colcon packages which re-use the same extension frameworks.