### PR TITLE
Add colcon_core.logging.get_effective_console_level function

### DIFF
--- a/colcon_core/executor/sequential.py
+++ b/colcon_core/executor/sequential.py
@@ -10,6 +10,7 @@ import traceback
 from colcon_core.executor import ExecutorExtensionPoint
 from colcon_core.executor import OnError
 from colcon_core.logging import colcon_logger
+from colcon_core.logging import get_effective_console_level
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.subprocess import new_event_loop
 from colcon_core.subprocess import SIGINT_RESULT
@@ -32,7 +33,8 @@ class SequentialExecutor(ExecutorExtensionPoint):
     def execute(self, args, jobs, *, on_error=OnError.interrupt):  # noqa: D102
         # avoid debug message from asyncio when colcon uses debug log level
         asyncio_logger = logging.getLogger('asyncio')
-        asyncio_logger.setLevel(logging.INFO)
+        log_level = get_effective_console_level(colcon_logger)
+        asyncio_logger.setLevel(log_level)
 
         rc = 0
         loop = new_event_loop()

--- a/colcon_core/logging.py
+++ b/colcon_core/logging.py
@@ -127,3 +127,20 @@ def add_file_handler(logger, path):
     logger.setLevel(1)
 
     return handler
+
+
+def get_effective_console_level(logger):
+    """
+    Determine the effective log level of to the console.
+
+    On a typical logger, this is the same as getEffectiveLevel(). After a call
+    to add_file_handler, this will continue to return the same level though
+    getEffectiveLevel() will now always return ``1``.
+
+    :param logger: The logger to inspect
+    :returns: the log level
+    """
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            return handler.level
+    return logger.getEffectiveLevel()


### PR DESCRIPTION
When colcon routes log messages to log files at a different level from the console, it makes it a little more convoluted to determine what log level is actually set.

When we're utilizing non-colcon libraries that also use python's logging module (e.x. ros_buildfarm, rosdistro, etc), we'll typically want to "synchronize" colcon's configured log level with the other library. This function can be used to determine what level colcon's console logging is set to.