### PR TITLE
Add some basic test coverage for build/test verbs

### DIFF
--- a/test/test_verb_build.py
+++ b/test/test_verb_build.py
@@ -29,12 +29,10 @@ class NoopBuildTask(TaskExtensionPoint):
 
 @pytest.fixture(scope='module', autouse=True)
 def patch_other_extension_args():
-    with (
-        patch('colcon_core.verb.build.add_event_handler_arguments'),
-        patch('colcon_core.verb.build.add_executor_arguments'),
-        patch('colcon_core.verb.build.add_packages_arguments'),
-        patch('colcon_core.verb.build.add_task_arguments'),
-    ):
+    with patch('colcon_core.verb.build.add_event_handler_arguments'), \
+            patch('colcon_core.verb.build.add_executor_arguments'), \
+            patch('colcon_core.verb.build.add_packages_arguments'), \
+            patch('colcon_core.verb.build.add_task_arguments'):
         yield
 
 

--- a/test/test_verb_test.py
+++ b/test/test_verb_test.py
@@ -29,12 +29,10 @@ class NoopTestTask(TaskExtensionPoint):
 
 @pytest.fixture(scope='module', autouse=True)
 def patch_other_extension_args():
-    with (
-        patch('colcon_core.verb.test.add_event_handler_arguments'),
-        patch('colcon_core.verb.test.add_executor_arguments'),
-        patch('colcon_core.verb.test.add_packages_arguments'),
-        patch('colcon_core.verb.test.add_task_arguments'),
-    ):
+    with patch('colcon_core.verb.test.add_event_handler_arguments'), \
+            patch('colcon_core.verb.test.add_executor_arguments'), \
+            patch('colcon_core.verb.test.add_packages_arguments'), \
+            patch('colcon_core.verb.test.add_task_arguments'):
         yield
 
 


### PR DESCRIPTION
Nothing crazy, just want to exercise the code to give us some basic coverage. The `build` verb is currently at 0%, so it's not hard to improve on that.