### PR TITLE
Hide verb block from help if there are no verbs

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -428,7 +428,9 @@ def create_subparser(parser, cmd_name, verb_extensions, *, attribute):
         title=f'{cmd_name} verbs',
         description='\n'.join(verbs) or None,
         dest=attribute,
-        help=f'call `{cmd_name} VERB -h` for specific help' if verbs else None,
+        help=(
+            f'call `{cmd_name} VERB -h` for specific help' if
+            verbs else argparse.SUPPRESS),
     )
     return subparser
 


### PR DESCRIPTION
Rather than show an empty verb block when there are no verbs, just hide the block from the help text entirely.

Before:
```
$ COLCON_EXTENSION_BLOCKLIST=colcon_core.verb colcon --help
usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL] {} ...

options:
  -h, --help            show this help message and exit
  --log-base LOG_BASE   The base path for all log directories (default: ./log, to disable: /dev/null)
  --log-level LOG_LEVEL
                        Set log level for the console output, either by numeric or string value (default: warning)

colcon verbs:
  {}

Environment variables:
  ...
```

After:
```
$ COLCON_EXTENSION_BLOCKLIST=colcon_core.verb colcon --help
usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL]

options:
  -h, --help            show this help message and exit
  --log-base LOG_BASE   The base path for all log directories (default: ./log, to disable: /dev/null)
  --log-level LOG_LEVEL
                        Set log level for the console output, either by numeric or string value (default: warning)

Environment variables:
  ...
```

Follow-up to #620