### PR TITLE
Add support to logging directory setup for no verb

### DIFF
--- a/colcon_core/location.py
+++ b/colcon_core/location.py
@@ -211,10 +211,13 @@ def create_log_path(verb_name):
     ignore_marker.touch()
 
     # create latest symlinks
-    _create_symlink(path, path.parent / f'latest_{verb_name}')
-    _create_symlink(
-        path.parent / f'latest_{verb_name}',
-        path.parent / 'latest')
+    if verb_name is None:
+        _create_symlink(path, path.parent / 'latest')
+    else:
+        _create_symlink(path, path.parent / f'latest_{verb_name}')
+        _create_symlink(
+            path.parent / f'latest_{verb_name}',
+            path.parent / 'latest')
 
 
 def _reset_log_path_creation_global():

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -190,6 +190,17 @@ def test_create_log_path(reset_log_path_creation_global):
         assert (log_path / subdirectory).exists()
         assert not (log_path / 'latest').is_symlink()
 
+        # check that `latest_verb` is skipped when there is no verb
+        (log_path / subdirectory).rmdir()
+        (log_path / 'latest').rmdir()
+        (log_path / 'latest_verb').unlink()
+        location._create_log_path_called = False
+        create_log_path(None)
+        assert (log_path / subdirectory).exists()
+        assert (log_path / 'latest').is_symlink()
+        assert (log_path / 'latest').resolve() == \
+            (log_path / subdirectory).resolve()
+
 
 def test__create_symlink():
     # check cases where functions raise exceptions and ensure it is being


### PR DESCRIPTION
Explicitly support "no verb" in the logging directory setup, as opposed to treating it as an empty string or raising an exception.