### PR TITLE
Add more tests for EmPy template expansion

### DIFF
--- a/test/test_shell_template.py
+++ b/test/test_shell_template.py
@@ -42,6 +42,17 @@ def test_expand_template():
             f" processing template '{template_path}'")
         assert not destination_path.exists()
 
+        # proper use
+        expand_template(template_path, destination_path, {'var': 'value1'})
+        assert destination_path.exists()
+        assert destination_path.read_text() == 'value1'
+        # overwrite with a different value
+        expand_template(template_path, destination_path, {'var': 'value2'})
+        assert destination_path.exists()
+        assert destination_path.read_text() == 'value2'
+
+        destination_path.unlink()
+
         # skip all symlink tests on Windows for now
         if sys.platform == 'win32':  # pragma: no cover
             return


### PR DESCRIPTION
The 'positive' case was previously completely uncovered on Windows, and there was also no test asserting that the caching mechanism respected differing input variables.