### PR TITLE
Re-work EmPy token caching

### DIFF
--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -78,16 +78,15 @@ class CachingInterpreter(BypassStdoutInterpreter):
             super().__init__(decoree, _cache=cache, _idx=0)
 
         def one(self, *args, **kwargs):
-            try:
+            if self._idx < len(self._cache):
                 token, count = self._cache[self._idx]
-            except IndexError:
+                self.advance(count)
+                self.sync()
+            else:
                 count = len(self._decoree)
                 token = self._decoree.one(*args, **kwargs)
                 count -= len(self._decoree)
                 self._cache.append((token, count))
-            else:
-                self.advance(count)
-                self.sync()
 
             self._idx += 1
             return token


### PR DESCRIPTION
The previous approach was to re-implement Interpreter.parse() to iterate over cached tokens where possible. This proved to be a problem when the implementation changed in EmPy 4.x.

The approach implemented here is to create a shim between the Interpreter and Scanner API and record/inject the tokens there, which improves the compatibility by working only at the API boundary and not duplicating chunks of the upstream implementation.

Note that I haven't actually benchmarked either of these caching implementations. They may not be worth the complexity.