### PR TITLE
Make BypassStdoutInterpreter compatible with EmPy 4.x

### DIFF
--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -61,9 +61,12 @@ def expand_template(template_path, destination_path, data):
 class BypassStdoutInterpreter(Interpreter):
     """Interpreter for EmPy which keeps `stdout` unchanged."""
 
-    def installProxy(self):  # noqa: D102 N802
+    def installProxy(self, *args, **kwargs):  # noqa: D102 N802
         # avoid replacing stdout with ProxyFile
-        pass
+        # in EmPy 3.x, this function performed in-place modification.
+        # in EmPy 4.x, it is passed the output stream and is expected to
+        # return the output stream.
+        return next(iter(args), None)
 
 
 cached_tokens = {}


### PR DESCRIPTION
Nothing much really changes here, but EmPy 4.x does some confusing things with the `output` option when `useProxy` is `False`, which we must set (in a separate change) to deal with stdout getting flushed/closed/etc.

In addition to keeping EmPy from modifying `sys.stdout`, this change also aligns the behavior of EmPy 4.x with 3.x with regard to the `output` option. IMO this is a bug in 4.x, but I don't really have the energy to figure out how to report it.