### PR TITLE
Use 'output' to configure EmPy v4 redirection

### DIFF
--- a/colcon_core/shell/template/__init__.py
+++ b/colcon_core/shell/template/__init__.py
@@ -43,9 +43,9 @@ def expand_template(template_path, destination_path, data):
                 output=output, options={OVERRIDE_OPT: False})
         else:
             interpreter = CachingInterpreter(
+                output=output,
                 config=Configuration(
                     defaultRoot=str(template_path),
-                    defaultStdout=output,
                     useProxy=False),
                 dispatcher=False)
         try:


### PR DESCRIPTION
This aligns with our strategy for earlier EmPy versions and avoids an assertion deep in EmPy v4 if 'output' is unspecified.

Follow-up to #665 