### PR TITLE
Support old 'toml' package for Focal

### DIFF
--- a/colcon_core/python_project/spec.py
+++ b/colcon_core/python_project/spec.py
@@ -3,9 +3,12 @@
 
 try:
     # Python 3.11+
-    from tomllib import load as toml_load
+    from tomllib import loads as toml_loads
 except ImportError:
-    from tomli import load as toml_load
+    try:
+        from tomli import loads as toml_loads
+    except ImportError:
+        from toml import loads as toml_loads
 
 
 SPEC_NAME = 'pyproject.toml'
@@ -25,7 +28,7 @@ def load_spec(project_path):
     spec_file = project_path / SPEC_NAME
     try:
         with spec_file.open('rb') as f:
-            spec = toml_load(f)
+            spec = toml_loads(f.read().decode())
     except FileNotFoundError:
         spec = {}
 

--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -5,7 +5,7 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 
 --- setup.cfg	2018-05-27 11:22:33.000000000 -0700
 +++ setup.cfg.patched	2018-05-27 11:22:33.000000000 -0700
-@@ -33,9 +33,12 @@
+@@ -33,11 +33,16 @@
  	importlib-metadata; python_version < "3.8"
  	packaging
  	pytest
@@ -19,5 +19,10 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 +	# pytest-repeat
 +	# pytest-rerunfailures
  	setuptools>=30.3.0
- 	tomli>=1.0.0; python_version < "3.11"
+-	tomli>=1.0.0; python_version < "3.11"
++	# toml is also supported, rely on deb dependencies to select the
++	# appropriate package
++	# tomli>=1.0.0; python_version < "3.11"
  packages = find:
+ zip_safe = false
+ 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
   pytest-repeat
   pytest-rerunfailures
   setuptools>=30.3.0
+  # toml is also supported but deprecated
   tomli>=1.0.0; python_version < "3.11"
 packages = find:
 zip_safe = false

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [colcon-core]
 No-Python2:
-Depends3: python3-distlib, python3-empy, python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata, python3 (>= 3.11) | python3-tomli (>= 1)
+Depends3: python3-distlib, python3-empy, python3-packaging, python3-pytest, python3-setuptools, python3 (>= 3.8) | python3-importlib-metadata, python3 (>= 3.11) | python3-tomli (>= 1) | python3-toml
 Recommends3: python3-pytest-cov
 Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
 Replaces3: colcon


### PR DESCRIPTION
I'm not thrilled about using the deprecated 'toml' package, but tomli isn't available in Focal as a system package. The changes here will only fall back to 'toml' as a last resort, which should allow us to keep Focal support alive for a while longer.

This should address the deb regression on Focal in colcon-core 0.18.0.