### PR TITLE
Suppress the "easy_install command is deprecated" warning.

### DIFF
--- a/colcon_core/task/python/build.py
+++ b/colcon_core/task/python/build.py
@@ -29,6 +29,8 @@ _PYTHON_CMD = [
     sys.executable,
     '-W',
     'ignore:setup.py install is deprecated',
+    '-W',
+    'ignore:easy_install command is deprecated',
 ]
 
 


### PR DESCRIPTION
This warning comes up when building ament_python packages with the --symlink-install option.

This is similar to https://github.com/colcon/colcon-core/pull/626, but for symlink installs.

This should "fix" https://github.com/ros2/ros2/issues/1577 .