### PR TITLE
Skip scspell tests on Python 3.13+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ test =
   pylint
   pytest
   pytest-cov
-  scspell3k>=2.2
+  scspell3k>=2.2; python_version < "3.13"
 
 [options.packages.find]
 exclude =

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -16,9 +17,14 @@ def known_words():
 
 @pytest.mark.linter
 def test_spell_check(known_words):
-    from scspell import Report
-    from scspell import SCSPELL_BUILTIN_DICT
-    from scspell import spell_check
+    try:
+        from scspell import Report
+        from scspell import SCSPELL_BUILTIN_DICT
+        from scspell import spell_check
+    except ModuleNotFoundError:
+        if sys.version_info >= (3, 13):
+            pytest.skip('scspell3k is not available for Python 3.13+')
+        raise
 
     source_filenames = [
         Path(__file__).parents[1] / 'bin' / 'colcon',


### PR DESCRIPTION
At this time, scspell is not available for Python 3.13 due to the removal of lib2to3. Until we have another solution, we should skip scspell on Python 3.13 so that we can add that version to the CI matrix as soon as possible.