### PR TITLE
Skip legacy entry_point tests on Python 3.13+

### DIFF
--- a/test/test_entry_point.py
+++ b/test/test_entry_point.py
@@ -2,21 +2,29 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
+import sys
 from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
+
+import pytest
 
 with warnings.catch_warnings():
     warnings.filterwarnings(
         'ignore', message='.*entry_point.*deprecated.*', category=UserWarning)
 
-    from colcon_core.entry_point import EXTENSION_POINT_GROUP_NAME
-    from colcon_core.entry_point import get_all_entry_points
-    from colcon_core.entry_point import get_entry_points
-    from colcon_core.entry_point import load_entry_point
-    from colcon_core.entry_point import load_entry_points
-
-import pytest
+    try:
+        from colcon_core.entry_point import EXTENSION_POINT_GROUP_NAME
+        from colcon_core.entry_point import get_all_entry_points
+        from colcon_core.entry_point import get_entry_points
+        from colcon_core.entry_point import load_entry_point
+        from colcon_core.entry_point import load_entry_points
+    except ModuleNotFoundError:
+        if sys.version_info >= (3, 13):
+            pytest.skip(
+                'pkg_resources is no longer available in Python 3.13+',
+                allow_module_level=True)
+        raise
 
 from .environment_context import EnvironmentContext
 


### PR DESCRIPTION
These tests require pkg_resources, which was removed in Python 3.13.

Note that the `entry_point` API has been deprecated since #562 and is no longer used in any colcon packages maintained here.