### PR TITLE
Add '+upstream' suffix to published deb version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,4 +6,4 @@ Suggests3: python3-pytest-repeat, python3-pytest-rerunfailures
 Replaces3: colcon
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6
-Debian-Version: 100
+Upstream-Version-Suffix: +upstream


### PR DESCRIPTION
We continue to see interference between the deb packages we publish from the colcon project and efforts to package colcon as part of mainline Debian and Ubuntu. Using a high Debian-Version value mitigated the problems in most cases, but was not sufficient to eliminate all of the conflicts we're currently experiencing.

Using a debian version suffix which falls late alphabetically appears to give our packages preference by apt. If a user enables a repository which distributes packages created by the colcon project, it is likely that they wish to use these packages instead of the ones packaged by their platform.

Related to colcon/colcon-argcomplete#43 and colcon/colcon.readthedocs.org#103