### PR TITLE
More gracefully handle crashes in pytest.

### DIFF
--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -171,9 +171,9 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             EXIT_CODE_NO_TESTS = EXIT_NOTESTSCOLLECTED  # noqa: N806
 
         if sys.platform == 'win32':
-            EXIT_CODE_TESTS_CRASHED = 3221225477
+            EXIT_CODE_TESTS_CRASHED = 3221225477  # noqa: N806
         else:
-            EXIT_CODE_TESTS_CRASHED = -11
+            EXIT_CODE_TESTS_CRASHED = -11  # noqa: N806
 
         if completed.returncode in (
             EXIT_CODE_TESTS_FAILED, EXIT_CODE_TESTS_CRASHED


### PR DESCRIPTION
When the pytest executable is executing, there is some possibility that it can crash (due to a bug in C extensions, for instance).  In the current code, this circumstance causes the main colcon executable to return a non-zero exit number.

But that doesn't seem correct; colcon didn't fail, one of the tests did.  The test should be marked as failing, but colcon itself should return a success code.  Additionally, we notice that if a e.g. ctest test crashes, colcon returns 0.

The reason this happens only with pytest is because pytest doesn't have a mechanism to suppress these kinds of errors.  Thus if the python interpreter in the pytest process crashes, pytest returns the segmentation fault number (-11 on Linux, 0xc0000005 on Windows).

Handle this by explicitly capturing this fault number, and setting the test to failed.  Unfortunately there are no convenient constants in Python that I could find for these numbers, so they are hardcoded here.

This does change the user-visible functioning of colcon, but I believe it does so for the better, and it is a bit of a corner case.