### PR TITLE
Extend package discovery to support passive mechanisms

### DIFF
--- a/colcon_core/package_discovery/__init__.py
+++ b/colcon_core/package_discovery/__init__.py
@@ -237,11 +237,10 @@ def _get_extensions_with_parameters(
                 f"'{extension.PACKAGE_DISCOVERY_NAME}': {e}\n{exc}")
             # skip failing extension, continue with next one
         else:
-            if has_parameter is not None:
-                if has_parameter:
-                    explicitly_specified = True
-                else:
-                    continue
+            if has_parameter:
+                explicitly_specified = True
+            elif has_parameter is not None:
+                continue
             with_parameters[extension.PACKAGE_DISCOVERY_NAME] = extension
     return with_parameters if explicitly_specified else OrderedDict()
 

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -110,6 +110,7 @@ def test_discover_packages():
             return_value={PackageDescriptor('/extension1/pkg1')})
         extensions['extension2'].discover = Mock(
             return_value={PackageDescriptor('/extension2/pkg1')})
+        extensions['extension2'].has_parameters = Mock(return_value=None)
 
         descs = discover_packages(None, None, discovery_extensions=extensions)
         assert len(descs) == 2
@@ -126,10 +127,12 @@ def test_discover_packages():
                 PackageDescriptor('/extension3/pkg2')})
 
         descs = discover_packages(None, None, discovery_extensions=extensions)
-        assert len(descs) == 2
+        assert len(descs) == 3
         expected_path = '/extension3/pkg1'.replace('/', os.sep)
         assert expected_path in (str(d.path) for d in descs)
         expected_path = '/extension3/pkg2'.replace('/', os.sep)
+        assert expected_path in (str(d.path) for d in descs)
+        expected_path = '/extension2/pkg1'.replace('/', os.sep)
         assert expected_path in (str(d.path) for d in descs)
 
 


### PR DESCRIPTION
The current implementation of package discovery follows one of two paths:
1. None of the extensions were specifically enabled via a command line argument, in which case all of the extensions are engaged.
2. Some subset of the extensions were given arguments, in which case the others are ignored and their discover() methods are not called.

This change adds support for discovery extensions which do not expose command line arguments and cannot therefore be specifically enabled, and ensures that those extensions are always engaged.

This is a non-breaking enhancement of the PackageDiscoveryExtensionPoint interface.