### PR TITLE
Allow executor extensions to publish events

### DIFF
--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -141,7 +141,7 @@ class ExecutorExtensionPoint:
     """
 
     """The version of the executor extension interface."""
-    EXTENSION_POINT_VERSION = '1.0'
+    EXTENSION_POINT_VERSION = '1.1'
 
     """The default priority of executor extensions."""
     PRIORITY = 100
@@ -190,6 +190,14 @@ class ExecutorExtensionPoint:
           `on_error` instead)
         """
         raise NotImplementedError()
+
+    def put_event_into_queue(self, event):
+        """
+        Post a message event into the event queue.
+
+        :param event: The event
+        """
+        self._event_controller.get_queue().put((event, self))
 
     def _flush(self):
         if self._event_controller is None:

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -123,9 +123,12 @@ def test_interface():
     interface = ExecutorExtensionPoint()
     interface._flush()
     event_controller = Mock()
+    event_controller.get_queue.returns = Mock()
     interface.set_event_controller(event_controller)
+    interface.put_event_into_queue(object())
     interface._flush()
     assert event_controller.flush.call_count == 1
+    assert event_controller.get_queue().put.call_count == 1
 
 
 class Extension1(ExecutorExtensionPoint):


### PR DESCRIPTION
The active executor extension already has a private variable holding the event controller, so it's not difficult to add a method to allow implementations of the executor extensions to publish events as well.