### PR TITLE
Fix a regression in recursive dependency enumeration

### DIFF
--- a/colcon_core/package_descriptor.py
+++ b/colcon_core/package_descriptor.py
@@ -114,7 +114,8 @@ class PackageDescriptor:
         :raises AssertionError: if a package lists itself as a dependency
         """
         if not isinstance(recursive_categories, Mapping):
-            recursive_categories = defaultdict(lambda: recursive_categories)
+            non_map_categories = recursive_categories
+            recursive_categories = defaultdict(lambda: non_map_categories)
         # the following variable only exists for faster access within the loop
         descriptors_by_name = defaultdict(set)
         for d in descriptors:
@@ -138,7 +139,7 @@ class PackageDescriptor:
                     continue
                 categories = set()
                 for category in dep.metadata['categories']:
-                    cats = recursive_categories.get(category)
+                    cats = recursive_categories[category]
                     if cats is None:
                         categories = None
                         break


### PR DESCRIPTION
There were two bugs in a previous change to recursive dependency enumeration. The first relates specifically to `defaultdict` behaviors, and the other to lambda capture.

Fixes #646

Keeping in draft until I can add tests.