### PR TITLE
Treat distutils as a 3rd party module

### DIFF
--- a/colcon_core/distutils/commands/symlink_data.py
+++ b/colcon_core/distutils/commands/symlink_data.py
@@ -1,8 +1,9 @@
 # Copyright 2023 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
-from distutils.command.install_data import install_data
 import os
+
+from distutils.command.install_data import install_data  # noqa: I100,I202
 
 
 class symlink_data(install_data):  # noqa: N801


### PR DESCRIPTION
In Python 3.12 and newer, distutils is no longer part of the standard library. It appears that flake8 has been updated to regard it as such, so we need to update our import order.

Until the updated flake8 is ubiquitous, we'll need to specifically suppress the linting for those older versions.