### PR TITLE
Fix error on inline comments in Python dependencies

### DIFF
--- a/colcon_core/package_augmentation/python.py
+++ b/colcon_core/package_augmentation/python.py
@@ -121,6 +121,9 @@ def create_dependency_descriptor(requirement_string):
         '<': 'version_lt',
     }
 
+    # Drop inline comments
+    requirement_string = requirement_string.partition(' #')[0]
+
     requirement = parse_requirement(requirement_string)
     metadata = {
         'origin': 'python',

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -161,3 +161,7 @@ def test_create_dependency_descriptor():
     dep = create_dependency_descriptor(multi_str)
     assert dep.metadata['version_gte'] == '2.2.0'
     assert dep.metadata['version_lte'] == '3.2.0'
+
+    commented_str = 'pkgname  # This is needed for foo'
+    dep = create_dependency_descriptor(commented_str)
+    assert dep.name == 'pkgname'


### PR DESCRIPTION
It appears that the distlib parsing function we're using here can't handle inline comments and raises a syntax error. After digging into the setuptools sources, it appears that these comments are dropped between parsing the file and parsing the individual dependencies, so we can do the same.

Needed to support syntax like this:
https://github.com/ros-infrastructure/rosdoc2/blob/d65d85509289d053a75bf69b1cfd4a9cca355cbc/setup.cfg#L56-L57

Hints for similar investigations:
https://github.com/pypa/setuptools/blob/9c4d383631d3951fcae0afd73b5d08ff5a262976/setuptools/dist.py#L399-L405
https://github.com/pypa/setuptools/blob/9c4d383631d3951fcae0afd73b5d08ff5a262976/setuptools/_reqs.py#L29
https://github.com/jaraco/jaraco.text/blob/10d49b85f8060bdfd64fa594bfd73a1356aab7e3/jaraco/text/__init__.py#L569-L581