### PR TITLE
Add Python 'platlib' directory to PYTHONPATH

### DIFF
--- a/colcon_core/environment/pythonpath.py
+++ b/colcon_core/environment/pythonpath.py
@@ -27,4 +27,14 @@ class PythonPathEnvironment(EnvironmentExtensionPoint):
                 'pythonpath', prefix_path, pkg_name,
                 'PYTHONPATH', str(rel_python_path), mode='prepend')
 
+        platlib_path = get_python_install_path(
+            'platlib', {'base': prefix_path, 'platbase': prefix_path})
+        if python_path != platlib_path:
+            logger.log(1, "checking '%s'" % platlib_path)
+            if platlib_path.exists():
+                rel_platlib_path = platlib_path.relative_to(prefix_path)
+                hooks += shell.create_environment_hook(
+                    'pythonpath', prefix_path, pkg_name,
+                    'PYTHONPATH', str(rel_platlib_path), mode='prepend')
+
         return hooks

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -78,6 +78,8 @@ optionxform
 pathlib
 pkgname
 pkgs
+platbase
+platlib
 plugin
 popitem
 prepend


### PR DESCRIPTION
Existing code looks for packages in paths like `.../lib/python3.X/site-packages`, but packages can also be installed to locations like `.../lib64/python3.X/site-packages`. We should look there as well.