### PR TITLE
Enhance tests for 'sh' and 'bat' shells

### DIFF
--- a/test/test_shell_bat.py
+++ b/test/test_shell_bat.py
@@ -208,10 +208,10 @@ def _test_prefix_script(prefix_path):
         subdirectory_path = str(prefix_path / 'subdirectory')
 
         # validate appending/prepending without existing values
-        with patch.dict(os.environ, {
-            'APPEND_NAME': '',
-            'PREPEND_NAME': '',
-        }):
+        with patch.dict(os.environ) as env_patch:
+            env_patch.pop('APPEND_NAME', None)
+            env_patch.pop('PREPEND_NAME', None)
+
             coroutine = _run_prefix_script(prefix_script)
             env = run_until_complete(coroutine)
             assert env.get('APPEND_NAME') == subdirectory_path

--- a/test/test_shell_sh.py
+++ b/test/test_shell_sh.py
@@ -210,10 +210,10 @@ def _test_prefix_script(prefix_path):
         subdirectory_path = str(prefix_path / 'subdirectory')
 
         # validate appending/prepending without existing values
-        with patch.dict(os.environ, {
-            'APPEND_NAME': '',
-            'PREPEND_NAME': '',
-        }):
+        with patch.dict(os.environ) as env_patch:
+            env_patch.pop('APPEND_NAME', None)
+            env_patch.pop('PREPEND_NAME', None)
+
             coroutine = _run_prefix_script(prefix_script)
             env = run_until_complete(coroutine)
             assert env.get('APPEND_NAME') == subdirectory_path


### PR DESCRIPTION
The existing tests exercise much of the code for implementing colcon's shell subsystem, but it doesn't validate the results. If the platform supports the shell, we should check that the code for appending and prepending paths to lists function as intended.

In each test module, the first block of changes is just a refactor so that we reference the hooks generated by the calls to `create_hook_*`. Previously, the test only validated that the hook could be generated, and didn't attempt to actually use it.

The second block adds a handful of assertions about the behavior of the hooks when executed.