### PR TITLE
Allow declaration of "out-of-band" dependencies

### DIFF
--- a/colcon_core/topological_order.py
+++ b/colcon_core/topological_order.py
@@ -41,14 +41,7 @@ def topological_order_decorators(decorators):
     for decorator in decorators:
         queued[decorator] = {
             d.name for d in decorator.recursive_dependencies
-        }
-
-    # map the set of out-of-band dependencies for each decorator
-    out_of_band = {}
-    for decorator in decorators:
-        out_of_band[decorator] = {
-            d.name for d in decorator.recursive_dependencies
-            if d.metadata.get('out_of_band')
+            if not d.metadata.get('out_of_band')
         }
 
     ordered = []
@@ -57,23 +50,9 @@ def topological_order_decorators(decorators):
         ordered_names = {d.descriptor.name for d in ordered}
         for q in queued.values():
             q.difference_update(ordered_names)
-        for oob in out_of_band.values():
-            oob.difference_update(ordered_names)
 
         # find all queued packages without remaining dependencies
         ready = [decorator for decorator, r in queued.items() if not r]
-        if not ready:
-            # if nothing is ready, try removing out-of-band dependencies
-            ready = [
-                decorator for decorator, r in queued.items()
-                if not r.difference(out_of_band[decorator])
-            ]
-            # prefer those with less out-of-band dependencies first
-            ready.sort(key=lambda d: (
-                len(out_of_band[d]), d.descriptor.name
-            ))
-            # take only one at a time
-            ready = ready[:1]
         if not ready:
             lines = [
                 '%s: %s' % (

--- a/colcon_core/topological_order.py
+++ b/colcon_core/topological_order.py
@@ -43,15 +43,37 @@ def topological_order_decorators(decorators):
             d.name for d in decorator.recursive_dependencies
         }
 
+    # map the set of out-of-band dependencies for each decorator
+    out_of_band = {}
+    for decorator in decorators:
+        out_of_band[decorator] = {
+            d.name for d in decorator.recursive_dependencies
+            if d.metadata.get('out_of_band')
+        }
+
     ordered = []
     while len(ordered) < len(decorators):
         # remove dependencies on already ordered packages
         ordered_names = {d.descriptor.name for d in ordered}
         for q in queued.values():
             q.difference_update(ordered_names)
+        for oob in out_of_band.values():
+            oob.difference_update(ordered_names)
 
         # find all queued packages without remaining dependencies
         ready = [decorator for decorator, r in queued.items() if not r]
+        if not ready:
+            # if nothing is ready, try removing out-of-band dependencies
+            ready = [
+                decorator for decorator, r in queued.items()
+                if not r.difference(out_of_band[decorator])
+            ]
+            # prefer those with less out-of-band dependencies first
+            ready.sort(key=lambda d: (
+                len(out_of_band[d]), d.descriptor.name
+            ))
+            # take only one at a time
+            ready = ready[:1]
         if not ready:
             lines = [
                 '%s: %s' % (

--- a/test/test_topological_order.py
+++ b/test/test_topological_order.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.topological_order import topological_order_packages
 import pytest
@@ -74,3 +75,23 @@ def test_topological_order_packages_with_circular_dependency():
     assert lines[1] == "one: ['three', 'two']"
     assert lines[2] == "three: ['one', 'two']"
     assert lines[3] == "two: ['one', 'three']"
+
+
+def test_topological_order_packages_with_out_of_band_dependency():
+    d1 = PackageDescriptor('/some/path')
+    d1.name = 'a'
+    d1.dependencies['run'].add(
+        DependencyDescriptor('b', metadata={'out_of_band': True}))
+    d1.dependencies['run'].add('c')
+
+    d2 = PackageDescriptor('/other/path')
+    d2.name = 'b'
+    d2.dependencies['run'].add('a')
+    d2.dependencies['run'].add(DependencyDescriptor('c'))
+
+    d3 = PackageDescriptor('/another/path')
+    d3.name = 'c'
+
+    decos = topological_order_packages({d1, d2, d3})
+    names = [d.descriptor.name for d in decos]
+    assert names == ['c', 'a', 'b']


### PR DESCRIPTION
The "out-of-band" declaration on a dependency is intended to indicate that the dependency is a requirement but not a prerequisite for processing. As such, operations like "--packages-up-to" and graph computation will still show the relationship, but the topological ordering operation will not require the dependency as a prerequisite.