### PR TITLE
Unify temporary directory allocation strategy in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+
+import pytest
+
+
+if getattr(pytest, 'version_tuple', ()) < (3, 9):
+    @pytest.fixture
+    def tmp_path(tmpdir):
+        """
+        Compatibility fixture for temporary directory allocation.
+
+        This can be removed when we drop support for platforms with Pytest
+        versions older than 3.9 (namely Enterprise Linux 8).
+        """
+        return Path(tmpdir)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,12 +1,16 @@
 # Copyright 2026 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+from itertools import takewhile
 from pathlib import Path
 
 import pytest
 
+pytest_version = tuple(
+    int(x) for x in takewhile(str.isdigit, pytest.__version__.split('.'))
+)
 
-if getattr(pytest, 'version_tuple', ()) < (3, 9):
+if pytest_version < (3, 9):
     @pytest.fixture
     def tmp_path(tmpdir):
         """

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -6,7 +6,6 @@ asyncio
 autouse
 backend
 backported
-basepath
 bazqux
 blocklist
 callables

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -54,6 +54,7 @@ https
 importlib
 importorskip
 isatty
+isdigit
 iterdir
 itertools
 junit
@@ -134,6 +135,7 @@ subprocesses
 symlink
 symlinks
 sysconfig
+takewhile
 tempfile
 terminalreporter
 testcase

--- a/test/test_build_python.py
+++ b/test/test_build_python.py
@@ -4,7 +4,6 @@
 import asyncio
 from contextlib import suppress
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
 from colcon_core.package_descriptor import PackageDescriptor
@@ -179,15 +178,16 @@ def _test_build_package(
 @pytest.mark.parametrize(
     'symlink_first',
     [False, True])
-def test_build_package(symlink_first, setup_cfg, libexec_pattern, data_files):
-    with TemporaryDirectory(prefix='test_colcon_') as tmp_path_str:
-        _test_build_package(
-            tmp_path_str, symlink_install=symlink_first,
-            setup_cfg=setup_cfg, libexec_pattern=libexec_pattern,
-            data_files=data_files)
+def test_build_package(
+    symlink_first, setup_cfg, libexec_pattern, data_files, tmp_path,
+):
+    tmp_path_str = str(tmp_path)
 
-        # Test again with the symlink flag inverted to validate cleanup
-        _test_build_package(
-            tmp_path_str, symlink_install=not symlink_first,
-            setup_cfg=setup_cfg, libexec_pattern=libexec_pattern,
-            data_files=data_files)
+    _test_build_package(
+        tmp_path_str, symlink_install=symlink_first, setup_cfg=setup_cfg,
+        libexec_pattern=libexec_pattern, data_files=data_files)
+
+    # Test again with the symlink flag inverted to validate cleanup
+    _test_build_package(
+        tmp_path_str, symlink_install=not symlink_first, setup_cfg=setup_cfg,
+        libexec_pattern=libexec_pattern, data_files=data_files)

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -6,7 +6,6 @@ import shutil
 import signal
 import sys
 from tempfile import mkdtemp
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -234,20 +233,19 @@ def test_prog_name_not_a_file():
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='Symlinks not supported.')
-def test_prog_name_symlink():
+def test_prog_name_symlink(tmp_path):
     # use __file__ since we know it exists
-    with TemporaryDirectory(prefix='test_colcon_') as temp_dir:
-        linked_file = os.path.join(temp_dir, 'test_command.py')
-        os.symlink(__file__, linked_file)
+    linked_file = tmp_path / 'test_command.py'
+    linked_file.symlink_to(__file__)
 
-        argv = [linked_file]
-        with patch('colcon_core.command.sys.argv', argv):
-            with patch(
-                'colcon_core.command.shutil.which',
-                return_value=__file__
-            ):
-                # prog should be shortened to the basename
-                assert get_prog_name() == 'test_command.py'
+    argv = [str(linked_file)]
+    with patch('colcon_core.command.sys.argv', argv):
+        with patch(
+            'colcon_core.command.shutil.which',
+            return_value=__file__
+        ):
+            # prog should be shortened to the basename
+            assert get_prog_name() == 'test_command.py'
 
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='Only valid on Windows.')

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,9 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -51,66 +49,60 @@ class Extension4(ShellExtensionPoint):
     pass
 
 
-def test_create_environment_scripts():
-    with TemporaryDirectory(prefix='test_colcon_') as basepath:
-        pkg = Mock()
-        pkg.name = 'name'
-        pkg.dependencies = {}
-        pkg.hooks = []
-        args = Mock()
-        args.install_base = basepath
+def test_create_environment_scripts(tmp_path):
+    pkg = Mock()
+    pkg.name = 'name'
+    pkg.dependencies = {}
+    pkg.hooks = []
+    args = Mock()
+    args.install_base = str(tmp_path)
 
-        # no hooks at all
+    # no hooks at all
+    with patch(
+        'colcon_core.environment.create_environment_hooks', return_value=[],
+    ):
         with patch(
-            'colcon_core.environment.create_environment_hooks', return_value=[]
+            'colcon_core.environment.get_shell_extensions', return_value={},
         ):
-            with patch(
-                'colcon_core.environment.get_shell_extensions', return_value={}
-            ):
-                create_environment_scripts(pkg, args)
+            create_environment_scripts(pkg, args)
 
-        pkg.hooks = [os.path.join(basepath, 'subA')]
-        with ExtensionPointContext(
-            extension3=Extension3, extension4=Extension4
-        ):
-            extensions = get_shell_extensions()
-            # one invalid return value, one check correct hooks argument
-            extensions[100]['extension3'].create_package_script = Mock()
-            extensions[100]['extension4'].create_package_script = Mock(
-                return_value=None)
-            with patch('colcon_core.environment.logger.error') as error:
-                create_environment_scripts(
-                    pkg, args, default_hooks=[('subB', )],
-                    additional_hooks=[['subC', 'arg1', 'arg2']])
-            # the raised exception is catched and results in an error message
-            assert error.call_count == 1
-            assert len(error.call_args[0]) == 1
-            assert error.call_args[0][0].startswith(
-                "Exception in shell extension 'extension3': "
-                'create_package_script() should return a list\n')
-            # check for correct hooks argument
-            mock = extensions[100]['extension4'].create_package_script
-            assert mock.call_count == 1
-            assert len(mock.call_args[0]) == 3
-            assert mock.call_args[0][0] == Path(args.install_base)
-            assert mock.call_args[0][1] == pkg.name
-            hook_tuples = mock.call_args[0][2]
-            assert len(hook_tuples) == 3
-            assert hook_tuples[0] == ('subB', ())
-            assert hook_tuples[1] == ('subC', ['arg1', 'arg2'])
-            assert hook_tuples[2] == ('subA', [])
+    pkg.hooks = [str(tmp_path / 'subA')]
+    with ExtensionPointContext(extension3=Extension3, extension4=Extension4):
+        extensions = get_shell_extensions()
+        # one invalid return value, one check correct hooks argument
+        extensions[100]['extension3'].create_package_script = Mock()
+        extensions[100]['extension4'].create_package_script = Mock(
+            return_value=None)
+        with patch('colcon_core.environment.logger.error') as error:
+            create_environment_scripts(
+                pkg, args, default_hooks=[('subB', )],
+                additional_hooks=[['subC', 'arg1', 'arg2']])
+        # the raised exception is catched and results in an error message
+        assert error.call_count == 1
+        assert len(error.call_args[0]) == 1
+        assert error.call_args[0][0].startswith(
+            "Exception in shell extension 'extension3': "
+            'create_package_script() should return a list\n')
+        # check for correct hooks argument
+        mock = extensions[100]['extension4'].create_package_script
+        assert mock.call_count == 1
+        assert len(mock.call_args[0]) == 3
+        assert mock.call_args[0][0] == Path(args.install_base)
+        assert mock.call_args[0][1] == pkg.name
+        hook_tuples = mock.call_args[0][2]
+        assert len(hook_tuples) == 3
+        assert hook_tuples[0] == ('subB', ())
+        assert hook_tuples[1] == ('subC', ['arg1', 'arg2'])
+        assert hook_tuples[2] == ('subA', [])
 
 
-def test_create_environment_hooks():
-    with TemporaryDirectory(prefix='test_colcon_') as basepath:
-        with ExtensionPointContext(
-            extension1=Extension1, extension2=Extension2
-        ):
-            with patch('colcon_core.environment.logger.error') as error:
-                hooks = create_environment_hooks(basepath, 'pkg_name')
+def test_create_environment_hooks(tmp_path):
+    with ExtensionPointContext(extension1=Extension1, extension2=Extension2):
+        with patch('colcon_core.environment.logger.error') as error:
+            hooks = create_environment_hooks(str(tmp_path), 'pkg_name')
     assert len(hooks) == 2
-    assert hooks[0] == f'{basepath}/share/pkg_name/hook/one.ext'
-    assert hooks[1] == f'{basepath}/share/pkg_name/hook/two.ext'
+    assert hooks[0] == f'{tmp_path}/share/pkg_name/hook/one.ext'
+    assert hooks[1] == f'{tmp_path}/share/pkg_name/hook/two.ext'
     # the raised exception is catched and results in an error message
     assert error.call_count == 1
     assert len(error.call_args[0]) == 1

--- a/test/test_environment_path.py
+++ b/test/test_environment_path.py
@@ -1,42 +1,38 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.environment.path import PathEnvironment
 
 
-def test_path():
+def test_path(tmp_path):
     extension = PathEnvironment()
 
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        with patch(
-            'colcon_core.shell.create_environment_hook',
-            return_value=['/some/hook', '/other/hook']
-        ):
-            # bin directory does not exist
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+    with patch(
+        'colcon_core.shell.create_environment_hook',
+        return_value=['/some/hook', '/other/hook']
+    ):
+        # bin directory does not exist
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, but empty
-            (prefix_path / 'bin').mkdir()
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+        # bin directory exists, but empty
+        (tmp_path / 'bin').mkdir()
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, but only subdirectories
-            (prefix_path / 'bin' / 'subdir').mkdir()
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+        # bin directory exists, but only subdirectories
+        (tmp_path / 'bin' / 'subdir').mkdir()
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, with file
-            (prefix_path / 'bin' / 'hook').write_text('')
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 2
+        # bin directory exists, with file
+        (tmp_path / 'bin' / 'hook').write_text('')
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 2
 
-            # bin directory exists, with files
-            (prefix_path / 'bin' / 'hook2').write_text('')
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 2
+        # bin directory exists, with files
+        (tmp_path / 'bin' / 'hook2').write_text('')
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 2

--- a/test/test_environment_pythonpath.py
+++ b/test/test_environment_pythonpath.py
@@ -1,30 +1,25 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.environment.pythonpath import PythonPathEnvironment
 from colcon_core.python_install_path import get_python_install_path
 
 
-def test_pythonpath():
+def test_pythonpath(tmp_path):
     extension = PythonPathEnvironment()
 
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        with patch(
-            'colcon_core.shell.create_environment_hook',
-            return_value=['/some/hook', '/other/hook']
-        ):
-            # Python path does not exist
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+    with patch(
+        'colcon_core.shell.create_environment_hook',
+        return_value=['/some/hook', '/other/hook'],
+    ):
+        # Python path does not exist
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # Python path exists
-            python_path = get_python_install_path(
-                'purelib', {'base': prefix_path})
-            python_path.mkdir(parents=True)
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 2
+        # Python path exists
+        python_path = get_python_install_path('purelib', {'base': tmp_path})
+        python_path.mkdir(parents=True)
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 2

--- a/test/test_environment_pythonscriptspath.py
+++ b/test/test_environment_pythonscriptspath.py
@@ -1,45 +1,40 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.environment.path import PythonScriptsPathEnvironment
 from colcon_core.python_install_path import get_python_install_path
 
 
-def test_path():
+def test_path(tmp_path):
     extension = PythonScriptsPathEnvironment()
 
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        scripts_path = get_python_install_path(
-            'scripts', {'base': prefix_path})
-        with patch(
-            'colcon_core.shell.create_environment_hook',
-            return_value=['/some/hook', '/other/hook']
-        ):
-            # bin directory does not exist
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+    scripts_path = get_python_install_path('scripts', {'base': tmp_path})
+    with patch(
+        'colcon_core.shell.create_environment_hook',
+        return_value=['/some/hook', '/other/hook'],
+    ):
+        # bin directory does not exist
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, but empty
-            scripts_path.mkdir()
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+        # bin directory exists, but empty
+        scripts_path.mkdir()
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, but only subdirectories
-            (scripts_path / 'subdir').mkdir()
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 0
+        # bin directory exists, but only subdirectories
+        (scripts_path / 'subdir').mkdir()
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 0
 
-            # bin directory exists, with file
-            (scripts_path / 'hook').write_text('')
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 2
+        # bin directory exists, with file
+        (scripts_path / 'hook').write_text('')
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 2
 
-            # bin directory exists, with files
-            (scripts_path / 'hook2').write_text('')
-            hooks = extension.create_environment_hooks(prefix_path, 'pkg_name')
-            assert len(hooks) == 2
+        # bin directory exists, with files
+        (scripts_path / 'hook2').write_text('')
+        hooks = extension.create_environment_hooks(tmp_path, 'pkg_name')
+        assert len(hooks) == 2

--- a/test/test_location.py
+++ b/test/test_location.py
@@ -3,7 +3,6 @@
 
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core import location
@@ -104,139 +103,135 @@ def reset_log_path_creation_global():
     location._reset_log_path_creation_global()
 
 
-def test_create_log_path(reset_log_path_creation_global):
+def test_create_log_path(reset_log_path_creation_global, tmp_path):
     subdirectory = 'sub'
-    with TemporaryDirectory(prefix='test_colcon_') as log_path:
-        log_path = Path(log_path)
-        set_default_log_path(base_path=log_path, subdirectory=subdirectory)
+    set_default_log_path(base_path=tmp_path, subdirectory=subdirectory)
 
-        # create a directory and symlink when the path doesn't exist
-        with patch('os.makedirs', wraps=os.makedirs) as makedirs:
-            create_log_path('verb')
-            makedirs.assert_called_once_with(str(log_path / subdirectory))
-        assert (log_path / subdirectory).exists()
-
-        # repeated call is a noop
-        with patch('os.makedirs') as makedirs:
-            makedirs.side_effect = AssertionError('should not be called')
-            create_log_path('verb')
-
-        # since the directory already exists create one with a suffix
-        location._create_log_path_called = False
-        with patch('os.makedirs', wraps=os.makedirs) as makedirs:
-            create_log_path('verb')
-            assert makedirs.call_count == 2
-            assert len(makedirs.call_args_list[0][0]) == 1
-            assert makedirs.call_args_list[0][0][0] == str(
-                log_path / subdirectory)
-            assert len(makedirs.call_args_list[1][0]) == 1
-            assert makedirs.call_args_list[1][0][0] == str(
-                log_path / subdirectory) + '_2'
-        assert (log_path / (str(subdirectory) + '_2')).exists()
-
-        # and another increment of the suffix
-        location._create_log_path_called = False
-        location._log_subdirectory = subdirectory
-        with patch('os.makedirs', wraps=os.makedirs) as makedirs:
-            create_log_path('verb')
-            assert makedirs.call_count == 3
-            assert len(makedirs.call_args_list[0][0]) == 1
-            assert makedirs.call_args_list[0][0][0] == str(
-                log_path / subdirectory)
-            assert len(makedirs.call_args_list[1][0]) == 1
-            assert makedirs.call_args_list[1][0][0] == str(
-                log_path / subdirectory) + '_2'
-            assert len(makedirs.call_args_list[2][0]) == 1
-            assert makedirs.call_args_list[2][0][0] == str(
-                log_path / subdirectory) + '_3'
-        assert (log_path / (str(subdirectory) + '_3')).exists()
-        subdirectory += '_3'
-
-        # check that `latest_verb` was created and points to the subdirectory
-        assert (log_path / 'latest_verb').is_symlink()
-        assert (log_path / 'latest_verb').resolve() == \
-            (log_path / subdirectory).resolve()
-
-        # check that `latest` was created and points to the subdirectory
-        assert (log_path / 'latest').is_symlink()
-        assert (log_path / 'latest').resolve() == \
-            (log_path / subdirectory).resolve()
-
-        # create directory but correct latest symlink already exists
-        (log_path / subdirectory).rmdir()
-        location._create_log_path_called = False
+    # create a directory and symlink when the path doesn't exist
+    with patch('os.makedirs', wraps=os.makedirs) as makedirs:
         create_log_path('verb')
-        assert (log_path / subdirectory).exists()
-        assert (log_path / 'latest').is_symlink()
-        assert (log_path / 'latest').resolve() == \
-            (log_path / subdirectory).resolve()
+        makedirs.assert_called_once_with(str(tmp_path / subdirectory))
+    assert (tmp_path / subdirectory).exists()
 
-        # create directory and update latest symlink
-        subdirectory = 'other_sub'
-        set_default_log_path(base_path=log_path, subdirectory=subdirectory)
-        location._create_log_path_called = False
+    # repeated call is a noop
+    with patch('os.makedirs') as makedirs:
+        makedirs.side_effect = AssertionError('should not be called')
         create_log_path('verb')
-        assert (log_path / subdirectory).exists()
-        assert (log_path / 'latest').is_symlink()
-        assert (log_path / 'latest').resolve() == \
-            (log_path / subdirectory).resolve()
 
-        # create directory but latest is not a symlink
-        (log_path / subdirectory).rmdir()
-        (log_path / 'latest').unlink()
-        (log_path / 'latest').mkdir()
-        location._create_log_path_called = False
+    # since the directory already exists create one with a suffix
+    location._create_log_path_called = False
+    with patch('os.makedirs', wraps=os.makedirs) as makedirs:
         create_log_path('verb')
-        assert (log_path / subdirectory).exists()
-        assert not (log_path / 'latest').is_symlink()
+        assert makedirs.call_count == 2
+        assert len(makedirs.call_args_list[0][0]) == 1
+        assert makedirs.call_args_list[0][0][0] == str(
+            tmp_path / subdirectory)
+        assert len(makedirs.call_args_list[1][0]) == 1
+        assert makedirs.call_args_list[1][0][0] == str(
+            tmp_path / subdirectory) + '_2'
+    assert (tmp_path / (str(subdirectory) + '_2')).exists()
 
-        # check that `latest_verb` is skipped when there is no verb
-        (log_path / subdirectory).rmdir()
-        (log_path / 'latest').rmdir()
-        (log_path / 'latest_verb').unlink()
-        location._create_log_path_called = False
-        create_log_path(None)
-        assert (log_path / subdirectory).exists()
-        assert (log_path / 'latest').is_symlink()
-        assert (log_path / 'latest').resolve() == \
-            (log_path / subdirectory).resolve()
+    # and another increment of the suffix
+    location._create_log_path_called = False
+    location._log_subdirectory = subdirectory
+    with patch('os.makedirs', wraps=os.makedirs) as makedirs:
+        create_log_path('verb')
+        assert makedirs.call_count == 3
+        assert len(makedirs.call_args_list[0][0]) == 1
+        assert makedirs.call_args_list[0][0][0] == str(
+            tmp_path / subdirectory)
+        assert len(makedirs.call_args_list[1][0]) == 1
+        assert makedirs.call_args_list[1][0][0] == str(
+            tmp_path / subdirectory) + '_2'
+        assert len(makedirs.call_args_list[2][0]) == 1
+        assert makedirs.call_args_list[2][0][0] == str(
+            tmp_path / subdirectory) + '_3'
+    assert (tmp_path / (str(subdirectory) + '_3')).exists()
+    subdirectory += '_3'
+
+    # check that `latest_verb` was created and points to the subdirectory
+    assert (tmp_path / 'latest_verb').is_symlink()
+    assert (tmp_path / 'latest_verb').resolve() == \
+        (tmp_path / subdirectory).resolve()
+
+    # check that `latest` was created and points to the subdirectory
+    assert (tmp_path / 'latest').is_symlink()
+    assert (tmp_path / 'latest').resolve() == \
+        (tmp_path / subdirectory).resolve()
+
+    # create directory but correct latest symlink already exists
+    (tmp_path / subdirectory).rmdir()
+    location._create_log_path_called = False
+    create_log_path('verb')
+    assert (tmp_path / subdirectory).exists()
+    assert (tmp_path / 'latest').is_symlink()
+    assert (tmp_path / 'latest').resolve() == \
+        (tmp_path / subdirectory).resolve()
+
+    # create directory and update latest symlink
+    subdirectory = 'other_sub'
+    set_default_log_path(base_path=tmp_path, subdirectory=subdirectory)
+    location._create_log_path_called = False
+    create_log_path('verb')
+    assert (tmp_path / subdirectory).exists()
+    assert (tmp_path / 'latest').is_symlink()
+    assert (tmp_path / 'latest').resolve() == \
+        (tmp_path / subdirectory).resolve()
+
+    # create directory but latest is not a symlink
+    (tmp_path / subdirectory).rmdir()
+    (tmp_path / 'latest').unlink()
+    (tmp_path / 'latest').mkdir()
+    location._create_log_path_called = False
+    create_log_path('verb')
+    assert (tmp_path / subdirectory).exists()
+    assert not (tmp_path / 'latest').is_symlink()
+
+    # check that `latest_verb` is skipped when there is no verb
+    (tmp_path / subdirectory).rmdir()
+    (tmp_path / 'latest').rmdir()
+    (tmp_path / 'latest_verb').unlink()
+    location._create_log_path_called = False
+    create_log_path(None)
+    assert (tmp_path / subdirectory).exists()
+    assert (tmp_path / 'latest').is_symlink()
+    assert (tmp_path / 'latest').resolve() == \
+        (tmp_path / subdirectory).resolve()
 
 
-def test__create_symlink():
+def test__create_symlink(tmp_path):
     # check cases where functions raise exceptions and ensure it is being
     # handled gracefully
-    with TemporaryDirectory(prefix='test_colcon_') as path:
-        path = Path(path)
 
-        # relative path couldn't be computed, symlink couldn't be created
-        _create_symlink(path / 'nowhere', Path('/foo/bar'))
+    # relative path couldn't be computed, symlink couldn't be created
+    _create_symlink(tmp_path / 'nowhere', Path('/foo/bar'))
 
-        # unlinking symlink failed
-        class DummyPath:
+    # unlinking symlink failed
+    class DummyPath:
 
-            def __init__(self):
-                self.parent = 'parent'
+        def __init__(self):
+            self.parent = 'parent'
 
-            def exists(self):
-                return False
+        def exists(self):
+            return False
 
-            def is_symlink(self):
-                return True
+        def is_symlink(self):
+            return True
 
-            def unlink(self):
-                raise FileNotFoundError()
+        def unlink(self):
+            raise FileNotFoundError()
 
-        with patch('os.symlink') as symlink:
-            _create_symlink(path / 'src', DummyPath())
-            assert symlink.call_count == 1
+    with patch('os.symlink') as symlink:
+        _create_symlink(tmp_path / 'src', DummyPath())
+        assert symlink.call_count == 1
 
-        # (Windows) OSError: symbolic link privilege not held
-        class ValidPath(DummyPath):
+    # (Windows) OSError: symbolic link privilege not held
+    class ValidPath(DummyPath):
 
-            def is_symlink(self):
-                return False
+        def is_symlink(self):
+            return False
 
-        with patch('os.symlink') as symlink:
-            symlink.side_effect = OSError()
-            _create_symlink(path / 'src', ValidPath())
-            assert symlink.call_count == 1
+    with patch('os.symlink') as symlink:
+        symlink.side_effect = OSError()
+        _create_symlink(tmp_path / 'src', ValidPath())
+        assert symlink.call_count == 1

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import logging
-from pathlib import Path
 from unittest.mock import Mock
 
 from colcon_core.logging import add_file_handler
@@ -61,8 +60,8 @@ def test_get_numeric_log_level():
     assert str(e.value).endswith('numeric log levels must be positive')
 
 
-def test_add_file_handler(tmpdir):
-    log_path = Path(tmpdir) / 'test_add_file_handler.log'
+def test_add_file_handler(tmp_path):
+    log_path = tmp_path / 'test_add_file_handler.log'
     log_path.touch()
     logger = logging.getLogger('test_add_file_handler')
     try:
@@ -79,7 +78,7 @@ def test_add_file_handler(tmpdir):
     assert log_path.stat().st_size > 10
 
 
-def test_get_effective_console_level(tmpdir):
+def test_get_effective_console_level(tmp_path):
     logger = logging.getLogger('test_sync_console_log_level')
 
     # no level set
@@ -92,7 +91,7 @@ def test_get_effective_console_level(tmpdir):
     assert level == logger.getEffectiveLevel() == logging.ERROR
 
     # after add_file_handler
-    log_path = Path(tmpdir) / 'test_add_file_handler.log'
+    log_path = tmp_path / 'test_add_file_handler.log'
     log_path.touch()
     try:
         add_file_handler(logger, log_path)

--- a/test/test_package_discovery.py
+++ b/test/test_package_discovery.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -136,22 +134,20 @@ def test_discover_packages():
         assert expected_path in (str(d.path) for d in descs)
 
 
-def test_expand_dir_wildcards():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        (prefix_path / 'one').mkdir()
-        (prefix_path / 'two').mkdir()
-        (prefix_path / 'three').touch()
+def test_expand_dir_wildcards(tmp_path):
+    (tmp_path / 'one').mkdir()
+    (tmp_path / 'two').mkdir()
+    (tmp_path / 'three').touch()
 
-        paths = [
-            '/some/path',
-            str(prefix_path / '*')
-        ]
-        expand_dir_wildcards(paths)
-        assert len(paths) == 3
-        assert paths[0] == '/some/path'
-        assert paths[1] == str((prefix_path / 'one'))
-        assert paths[2] == str((prefix_path / 'two'))
+    paths = [
+        '/some/path',
+        str(tmp_path / '*')
+    ]
+    expand_dir_wildcards(paths)
+    assert len(paths) == 3
+    assert paths[0] == '/some/path'
+    assert paths[1] == str((tmp_path / 'one'))
+    assert paths[2] == str((tmp_path / 'two'))
 
 
 def test__get_extensions_with_parameters():

--- a/test/test_package_discovery_path.py
+++ b/test/test_package_discovery_path.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -62,24 +60,22 @@ def test_discover():
             PackageDescriptor(os.path.realpath('/other/path'))}
 
 
-def test_discover_with_wildcards():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        path_one = prefix_path / 'one' / 'path'
-        path_two = prefix_path / 'two' / 'path'
-        path_three = prefix_path / 'three' / 'path'
-        path_one.mkdir(parents=True)
-        path_two.mkdir(parents=True)
-        path_three.mkdir(parents=True)
+def test_discover_with_wildcards(tmp_path):
+    path_one = tmp_path / 'one' / 'path'
+    path_two = tmp_path / 'two' / 'path'
+    path_three = tmp_path / 'three' / 'path'
+    path_one.mkdir(parents=True)
+    path_two.mkdir(parents=True)
+    path_three.mkdir(parents=True)
 
-        extension = PathPackageDiscovery()
-        args = Mock()
-        args.paths = [str(prefix_path / '*' / 'path')]
-        with patch(
-            'colcon_core.package_discovery.path.identify', side_effect=identify
-        ):
-            descs = extension.discover(args=args, identification_extensions={})
-            assert descs == {
-                PackageDescriptor(os.path.realpath(str(path_one))),
-                PackageDescriptor(os.path.realpath(str(path_two))),
-                PackageDescriptor(os.path.realpath(str(path_three)))}
+    extension = PathPackageDiscovery()
+    args = Mock()
+    args.paths = [str(tmp_path / '*' / 'path')]
+    with patch(
+        'colcon_core.package_discovery.path.identify', side_effect=identify
+    ):
+        descs = extension.discover(args=args, identification_extensions={})
+        assert descs == {
+            PackageDescriptor(os.path.realpath(str(path_one))),
+            PackageDescriptor(os.path.realpath(str(path_two))),
+            PackageDescriptor(os.path.realpath(str(path_three)))}

--- a/test/test_package_identification_ignore.py
+++ b/test/test_package_identification_ignore.py
@@ -1,8 +1,6 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 
 from colcon_core.package_identification import IgnoreLocationException
@@ -12,13 +10,12 @@ from colcon_core.package_identification.ignore \
 import pytest
 
 
-def test_identify():
+def test_identify(tmp_path):
     extension = IgnorePackageIdentification()
     metadata = Mock()
-    with TemporaryDirectory(prefix='test_colcon_') as basepath:
-        metadata.path = Path(basepath)
-        assert extension.identify(metadata) is None
+    metadata.path = tmp_path
+    assert extension.identify(metadata) is None
 
-        (metadata.path / IGNORE_MARKER).write_text('')
-        with pytest.raises(IgnoreLocationException):
-            extension.identify(metadata)
+    (metadata.path / IGNORE_MARKER).write_text('')
+    with pytest.raises(IgnoreLocationException):
+        extension.identify(metadata)

--- a/test/test_package_identification_python.py
+++ b/test/test_package_identification_python.py
@@ -1,9 +1,6 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 from colcon_core.package_augmentation.python \
     import create_dependency_descriptor
 from colcon_core.package_augmentation.python \
@@ -14,102 +11,99 @@ from colcon_core.package_identification.python \
 import pytest
 
 
-def test_identify():
+def test_identify(tmp_path):
     extension = PythonPackageIdentification()
     augmentation_extension = PythonPackageAugmentation()
 
-    with TemporaryDirectory(prefix='test_colcon_') as basepath:
-        desc = PackageDescriptor(basepath)
-        desc.type = 'other'
-        assert extension.identify(desc) is None
-        assert desc.name is None
+    desc = PackageDescriptor(str(tmp_path))
+    desc.type = 'other'
+    assert extension.identify(desc) is None
+    assert desc.name is None
 
-        desc.type = None
-        assert extension.identify(desc) is None
-        assert desc.name is None
-        assert desc.type is None
+    desc.type = None
+    assert extension.identify(desc) is None
+    assert desc.name is None
+    assert desc.type is None
 
-        basepath = Path(basepath)
-        (basepath / 'setup.py').write_text('setup()')
-        assert extension.identify(desc) is None
-        assert desc.name is None
-        assert desc.type is None
+    (tmp_path / 'setup.py').write_text('setup()')
+    assert extension.identify(desc) is None
+    assert desc.name is None
+    assert desc.type is None
 
-        (basepath / 'setup.cfg').write_text('')
-        assert extension.identify(desc) is None
-        assert desc.name is None
-        assert desc.type is None
+    (tmp_path / 'setup.cfg').write_text('')
+    assert extension.identify(desc) is None
+    assert desc.name is None
+    assert desc.type is None
 
-        (basepath / 'setup.cfg').write_text(
-            '[metadata]\n'
-            'name = pkg-name\n')
-        assert extension.identify(desc) is None
-        assert desc.name == 'pkg-name'
-        assert desc.type == 'python'
-        assert not desc.dependencies
-        assert not desc.metadata
+    (tmp_path / 'setup.cfg').write_text(
+        '[metadata]\n'
+        'name = pkg-name\n')
+    assert extension.identify(desc) is None
+    assert desc.name == 'pkg-name'
+    assert desc.type == 'python'
+    assert not desc.dependencies
+    assert not desc.metadata
 
-        augmentation_extension.augment_package(desc)
-        assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
-        assert not desc.dependencies['build']
-        assert not desc.dependencies['run']
-        assert not desc.dependencies['test']
+    augmentation_extension.augment_package(desc)
+    assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
+    assert not desc.dependencies['build']
+    assert not desc.dependencies['run']
+    assert not desc.dependencies['test']
 
-        desc = PackageDescriptor(basepath)
-        desc.name = 'other-name'
-        with pytest.raises(RuntimeError) as e:
-            extension.identify(desc)
-        assert str(e.value).endswith(
-            'Package name already set to different value')
-
-        (basepath / 'setup.cfg').write_text(
-            '[metadata]\n'
-            'name = other-name\n'
-            'maintainer = Foo Bar\n'
-            'maintainer_email = foobar@example.com\n'
-            '[options]\n'
-            'setup_requires =\n'
-            "  build; sys_platform != 'win32'\n"
-            "  build-windows; sys_platform == 'win32'\n"
-            'install_requires =\n'
-            '  runA > 1.2.3\n'
-            '  runB\n'
-            'zip_safe = false\n'
-            '[options.extras_require]\n'
-            'test = test2 == 3.0.0\n'
-            'tests = test3\n'
-            'testing = test4\n'
-            'other = not-test\n')
-        assert extension.identify(desc) is None
-        assert desc.name == 'other-name'
-        assert desc.type == 'python'
-        assert not desc.dependencies
-        assert not desc.metadata
-
-        augmentation_extension.augment_package(desc)
-        assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
-        assert desc.dependencies['build'] == {'build', 'build-windows'}
-        assert desc.dependencies['run'] == {'runA', 'runB'}
-        dep = next(x for x in desc.dependencies['run'] if x == 'runA')
-        assert dep.metadata['version_gt'] == '1.2.3'
-        assert desc.dependencies['test'] == {'test2', 'test3', 'test4'}
-
-        assert callable(desc.metadata['get_python_setup_options'])
-        options = desc.metadata['get_python_setup_options'](None)
-        assert 'zip_safe' in options
-
-        assert desc.metadata['maintainers'] == ['Foo Bar <foobar@example.com>']
-
-        desc = PackageDescriptor(basepath)
-        desc.name = 'other-name'
-        (basepath / 'setup.cfg').write_text(
-            '[metadata]\n'
-            'name = other-name\n'
-            'author = Baz Qux\n'
-            'author_email = bazqux@example.com\n')
+    desc = PackageDescriptor(tmp_path)
+    desc.name = 'other-name'
+    with pytest.raises(RuntimeError) as e:
         extension.identify(desc)
-        augmentation_extension.augment_package(desc)
-        assert desc.metadata['maintainers'] == ['Baz Qux <bazqux@example.com>']
+    assert str(e.value).endswith('Package name already set to different value')
+
+    (tmp_path / 'setup.cfg').write_text(
+        '[metadata]\n'
+        'name = other-name\n'
+        'maintainer = Foo Bar\n'
+        'maintainer_email = foobar@example.com\n'
+        '[options]\n'
+        'setup_requires =\n'
+        "  build; sys_platform != 'win32'\n"
+        "  build-windows; sys_platform == 'win32'\n"
+        'install_requires =\n'
+        '  runA > 1.2.3\n'
+        '  runB\n'
+        'zip_safe = false\n'
+        '[options.extras_require]\n'
+        'test = test2 == 3.0.0\n'
+        'tests = test3\n'
+        'testing = test4\n'
+        'other = not-test\n')
+    assert extension.identify(desc) is None
+    assert desc.name == 'other-name'
+    assert desc.type == 'python'
+    assert not desc.dependencies
+    assert not desc.metadata
+
+    augmentation_extension.augment_package(desc)
+    assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
+    assert desc.dependencies['build'] == {'build', 'build-windows'}
+    assert desc.dependencies['run'] == {'runA', 'runB'}
+    dep = next(x for x in desc.dependencies['run'] if x == 'runA')
+    assert dep.metadata['version_gt'] == '1.2.3'
+    assert desc.dependencies['test'] == {'test2', 'test3', 'test4'}
+
+    assert callable(desc.metadata['get_python_setup_options'])
+    options = desc.metadata['get_python_setup_options'](None)
+    assert 'zip_safe' in options
+
+    assert desc.metadata['maintainers'] == ['Foo Bar <foobar@example.com>']
+
+    desc = PackageDescriptor(tmp_path)
+    desc.name = 'other-name'
+    (tmp_path / 'setup.cfg').write_text(
+        '[metadata]\n'
+        'name = other-name\n'
+        'author = Baz Qux\n'
+        'author_email = bazqux@example.com\n')
+    extension.identify(desc)
+    augmentation_extension.augment_package(desc)
+    assert desc.metadata['maintainers'] == ['Baz Qux <bazqux@example.com>']
 
 
 def test_create_dependency_descriptor():

--- a/test/test_prefix_path.py
+++ b/test/test_prefix_path.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -39,7 +37,7 @@ def test_get_prefix_path_extensions():
     assert list(extensions[90].keys()) == ['extension1']
 
 
-def test_get_chained_prefix_path():
+def test_get_chained_prefix_path(tmp_path):
     ColconPrefixPath.PREFIX_PATH_NAME = 'colcon'
     with patch(
         'colcon_core.prefix_path.get_prefix_path_extensions',
@@ -57,40 +55,38 @@ def test_get_chained_prefix_path():
             prefix_path = get_chained_prefix_path(skip='/path/to/skip')
             assert prefix_path == []
 
-        with TemporaryDirectory(prefix='test_colcon_') as basepath:
-            basepath = Path(basepath)
-            with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
-                [str(basepath), str(basepath)]
-            )):
-                # multiple results, duplicates being skipped
-                prefix_path = get_chained_prefix_path(skip='/path/to/skip')
-                assert prefix_path == [str(basepath)]
+        with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
+            [str(tmp_path), str(tmp_path)]
+        )):
+            # multiple results, duplicates being skipped
+            prefix_path = get_chained_prefix_path(skip='/path/to/skip')
+            assert prefix_path == [str(tmp_path)]
 
-                # skipping results
-                prefix_path = get_chained_prefix_path(skip=str(basepath))
-                assert prefix_path == []
+            # skipping results
+            prefix_path = get_chained_prefix_path(skip=str(tmp_path))
+            assert prefix_path == []
 
-            # skipping non-existing results
-            with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
-                [str(basepath), str(basepath / 'non-existing-sub')]
-            )):
-                with patch(
-                    'colcon_core.prefix_path.colcon.logger.warning'
-                ) as warn:
-                    prefix_path = get_chained_prefix_path()
-                assert prefix_path == [str(basepath)]
-                assert warn.call_count == 1
-                assert len(warn.call_args[0]) == 1
-                assert warn.call_args[0][0].endswith(
-                    "non-existing-sub' in the environment variable "
-                    "COLCON_PREFIX_PATH doesn't exist")
-                # suppress duplicate warning
-                with patch(
-                    'colcon_core.prefix_path.colcon.logger.warning'
-                ) as warn:
-                    prefix_path = get_chained_prefix_path()
-                assert prefix_path == [str(basepath)]
-                assert warn.call_count == 0
+        # skipping non-existing results
+        with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
+            [str(tmp_path), str(tmp_path / 'non-existing-sub')]
+        )):
+            with patch(
+                'colcon_core.prefix_path.colcon.logger.warning'
+            ) as warn:
+                prefix_path = get_chained_prefix_path()
+            assert prefix_path == [str(tmp_path)]
+            assert warn.call_count == 1
+            assert len(warn.call_args[0]) == 1
+            assert warn.call_args[0][0].endswith(
+                "non-existing-sub' in the environment variable "
+                "COLCON_PREFIX_PATH doesn't exist")
+            # suppress duplicate warning
+            with patch(
+                'colcon_core.prefix_path.colcon.logger.warning'
+            ) as warn:
+                prefix_path = get_chained_prefix_path()
+            assert prefix_path == [str(tmp_path)]
+            assert warn.call_count == 0
 
     with ExtensionPointContext(extension1=Extension1, extension2=Extension2):
         extensions = get_prefix_path_extensions()

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import os
 from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -262,7 +261,7 @@ def test_create_environment_hook():
                 None, None, None, None, None, mode='invalid')
 
 
-def test_get_colcon_prefix_path():
+def test_get_colcon_prefix_path(tmp_path):
     # ignore deprecation warning
     with patch('colcon_core.shell.warnings.warn') as warn:
         # empty environment variable
@@ -275,84 +274,75 @@ def test_get_colcon_prefix_path():
             prefix_path = get_colcon_prefix_path(skip='/path/to/skip')
             assert prefix_path == []
 
-        with TemporaryDirectory(prefix='test_colcon_') as basepath:
-            basepath = Path(basepath)
-            with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
-                [str(basepath), str(basepath)]
-            )):
-                # multiple results
-                prefix_path = get_colcon_prefix_path(skip='/path/to/skip')
-                assert prefix_path == [str(basepath), str(basepath)]
+        with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
+            [str(tmp_path), str(tmp_path)]
+        )):
+            # multiple results
+            prefix_path = get_colcon_prefix_path(skip='/path/to/skip')
+            assert prefix_path == [str(tmp_path), str(tmp_path)]
 
-                # skipping results
-                prefix_path = get_colcon_prefix_path(skip=str(basepath))
-                assert prefix_path == []
+            # skipping results
+            prefix_path = get_colcon_prefix_path(skip=str(tmp_path))
+            assert prefix_path == []
 
-            # skipping non-existing results
-            with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
-                [str(basepath), str(basepath / 'non-existing-sub')]
-            )):
-                with patch('colcon_core.shell.logger.warning') as warn:
-                    prefix_path = get_colcon_prefix_path()
-                assert prefix_path == [str(basepath)]
-                assert warn.call_count == 1
-                assert len(warn.call_args[0]) == 1
-                assert warn.call_args[0][0].endswith(
-                    "non-existing-sub' in the environment variable "
-                    "COLCON_PREFIX_PATH doesn't exist")
-                # suppress duplicate warning
-                with patch('colcon_core.shell.logger.warning') as warn:
-                    prefix_path = get_colcon_prefix_path()
-                assert prefix_path == [str(basepath)]
-                assert warn.call_count == 0
+        # skipping non-existing results
+        with EnvironmentContext(COLCON_PREFIX_PATH=os.pathsep.join(
+            [str(tmp_path), str(tmp_path / 'non-existing-sub')]
+        )):
+            with patch('colcon_core.shell.logger.warning') as warn:
+                prefix_path = get_colcon_prefix_path()
+            assert prefix_path == [str(tmp_path)]
+            assert warn.call_count == 1
+            assert len(warn.call_args[0]) == 1
+            assert warn.call_args[0][0].endswith(
+                "non-existing-sub' in the environment variable "
+                "COLCON_PREFIX_PATH doesn't exist")
+            # suppress duplicate warning
+            with patch('colcon_core.shell.logger.warning') as warn:
+                prefix_path = get_colcon_prefix_path()
+            assert prefix_path == [str(tmp_path)]
+            assert warn.call_count == 0
 
 
-def test_check_dependency_availability():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
+def test_check_dependency_availability(tmp_path):
+    dependencies = OrderedDict()
+    dependencies['pkgA'] = tmp_path
 
-        dependencies = OrderedDict()
-        dependencies['pkgA'] = prefix_path
-
-        # missing package
-        with pytest.raises(RuntimeError) as e:
-            check_dependency_availability(
-                dependencies, script_filename='package.ext')
-        assert len(dependencies) == 1
-        assert 'Failed to find the following files:' in str(e.value)
-        assert str(prefix_path / 'share' / 'pkgA' / 'package.ext') \
-            in str(e.value)
-        assert 'Check that the following packages have been built:' \
-            in str(e.value)
-        assert '- pkgA' in str(e.value)
-
-        # package in workspace
-        (prefix_path / 'share' / 'pkgA').mkdir(parents=True)
-        (prefix_path / 'share' / 'pkgA' / 'package.ext').write_text('')
+    # missing package
+    with pytest.raises(RuntimeError) as e:
         check_dependency_availability(
             dependencies, script_filename='package.ext')
-        assert len(dependencies) == 1
+    assert len(dependencies) == 1
+    assert 'Failed to find the following files:' in str(e.value)
+    assert str(tmp_path / 'share' / 'pkgA' / 'package.ext') in str(e.value)
+    assert 'Check that the following packages have been built:' in str(e.value)
+    assert '- pkgA' in str(e.value)
 
-        # package in environment
-        dependencies['pkgA'] = prefix_path / 'invalid'
-        with patch(
-            'colcon_core.shell.find_installed_packages_in_environment',
-            side_effect=lambda: {'pkgA': prefix_path / 'env'}
-        ):
-            with patch('colcon_core.shell.logger.warning') as warn:
-                check_dependency_availability(
-                    dependencies, script_filename='package.ext')
-        assert len(dependencies) == 0
-        assert warn.call_count == 1
-        assert len(warn.call_args[0]) == 1
-        assert warn.call_args[0][0].startswith(
-            "The following packages are in the workspace but haven't been "
-            'built:')
-        assert '- pkgA' in warn.call_args[0][0]
-        assert 'They are being used from the following locations instead:' \
-            in warn.call_args[0][0]
-        assert str(prefix_path / 'env') in warn.call_args[0][0]
-        assert '--packages-ignore pkgA' in warn.call_args[0][0]
+    # package in workspace
+    (tmp_path / 'share' / 'pkgA').mkdir(parents=True)
+    (tmp_path / 'share' / 'pkgA' / 'package.ext').write_text('')
+    check_dependency_availability(dependencies, script_filename='package.ext')
+    assert len(dependencies) == 1
+
+    # package in environment
+    dependencies['pkgA'] = tmp_path / 'invalid'
+    with patch(
+        'colcon_core.shell.find_installed_packages_in_environment',
+        side_effect=lambda: {'pkgA': tmp_path / 'env'}
+    ):
+        with patch('colcon_core.shell.logger.warning') as warn:
+            check_dependency_availability(
+                dependencies, script_filename='package.ext')
+    assert len(dependencies) == 0
+    assert warn.call_count == 1
+    assert len(warn.call_args[0]) == 1
+    assert warn.call_args[0][0].startswith(
+        "The following packages are in the workspace but haven't been built:")
+    assert '- pkgA' in warn.call_args[0][0]
+    assert 'They are being used from the following locations instead:' \
+        in warn.call_args[0][0]
+    assert str(tmp_path / 'env') in warn.call_args[0][0]
+    assert '--packages-ignore pkgA' in warn.call_args[0][0]
 
 
 class FIExtension1(FindInstalledPackagesExtensionPoint):
@@ -378,85 +368,80 @@ def test_find_installed_packages_extension_not_implemented():
         FindInstalledPackagesExtensionPoint().find_installed_packages(Path())
 
 
-def test_find_installed_packages_in_environment():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
-        prefix_path1 = prefix_path / 'one'
-        prefix_path2 = prefix_path / 'two'
+def test_find_installed_packages_in_environment(tmp_path):
+    prefix_path1 = tmp_path / 'one'
+    prefix_path2 = tmp_path / 'two'
 
+    with patch(
+        'colcon_core.shell.get_chained_prefix_path',
+        return_value=[prefix_path1, prefix_path2]
+    ):
+        # not used prefixes result debug messages
+        with patch('colcon_core.shell.logger.debug') as debug:
+            find_installed_packages_in_environment()
+        assert debug.call_count == 2
+
+        # the package is picked up from the first prefix
         with patch(
-            'colcon_core.shell.get_chained_prefix_path',
-            return_value=[prefix_path1, prefix_path2]
+            'colcon_core.shell.find_installed_packages',
+            side_effect=lambda p: {'pkgA': p}
         ):
-            # not used prefixes result debug messages
-            with patch('colcon_core.shell.logger.debug') as debug:
-                find_installed_packages_in_environment()
-            assert debug.call_count == 2
-
-            # the package is picked up from the first prefix
-            with patch(
-                'colcon_core.shell.find_installed_packages',
-                side_effect=lambda p: {'pkgA': p}
-            ):
-                packages = find_installed_packages_in_environment()
-        assert len(packages) == 1
-        assert 'pkgA' in packages
-        assert packages['pkgA'] == prefix_path1
+            packages = find_installed_packages_in_environment()
+    assert len(packages) == 1
+    assert 'pkgA' in packages
+    assert packages['pkgA'] == prefix_path1
 
 
-def test_find_installed_packages():
+def test_find_installed_packages(tmp_path):
     with ExtensionPointContext(
         colcon_isolated=IsolatedInstalledPackageFinder,
         colcon_merged=MergedInstalledPackageFinder
     ):
-        with TemporaryDirectory(prefix='test_colcon_') as install_base:
-            install_base = Path(install_base)
+        # install base doesn't exist
+        assert find_installed_packages(tmp_path) is None
 
-            # install base doesn't exist
-            assert find_installed_packages(install_base) is None
+        # unknown install layout
+        marker_file = tmp_path / '.colcon_install_layout'
+        marker_file.write_text('unknown')
+        assert find_installed_packages(tmp_path) is None
 
-            # unknown install layout
-            marker_file = install_base / '.colcon_install_layout'
-            marker_file.write_text('unknown')
-            assert find_installed_packages(install_base) is None
+        # package index directory doesn't exist
+        marker_file.write_text('merged')
+        packages = find_installed_packages(tmp_path)
+        assert len(packages) == 0
 
-            # package index directory doesn't exist
+        with patch(
+            'colcon_core.shell.installed_packages'
+            '.get_relative_package_index_path',
+            return_value=Path('relative/package/index')
+        ) as rel_path:
+            # setup for isolated case
+            (tmp_path / 'dummy_file').write_text('')
+            (tmp_path / '.hidden_dir').mkdir()
+            (tmp_path / 'dummy_dir' / rel_path() / 'dummy_dir').mkdir(
+                parents=True)
+            (tmp_path / 'pkgA' / rel_path()).mkdir(parents=True)
+            (tmp_path / 'pkgA' / rel_path() / 'pkgA').write_text('')
+
+            # setup for merged case
+            (tmp_path / rel_path() / 'dummy_dir').mkdir(parents=True)
+            (tmp_path / rel_path() / '.dummy').write_text('')
+            (tmp_path / rel_path() / 'pkgB').write_text('')
+            (tmp_path / rel_path() / 'pkgC').write_text('')
+
+            marker_file.write_text('isolated')
+            packages = find_installed_packages(tmp_path)
+            assert len(packages) == 1
+            assert 'pkgA' in packages.keys()
+            assert packages['pkgA'] == tmp_path / 'pkgA'
+
             marker_file.write_text('merged')
-            packages = find_installed_packages(install_base)
-            assert len(packages) == 0
-
-            with patch(
-                'colcon_core.shell.installed_packages'
-                '.get_relative_package_index_path',
-                return_value=Path('relative/package/index')
-            ) as rel_path:
-                # setup for isolated case
-                (install_base / 'dummy_file').write_text('')
-                (install_base / '.hidden_dir').mkdir()
-                (install_base / 'dummy_dir' / rel_path() / 'dummy_dir').mkdir(
-                    parents=True)
-                (install_base / 'pkgA' / rel_path()).mkdir(parents=True)
-                (install_base / 'pkgA' / rel_path() / 'pkgA').write_text('')
-
-                # setup for merged case
-                (install_base / rel_path() / 'dummy_dir').mkdir(parents=True)
-                (install_base / rel_path() / '.dummy').write_text('')
-                (install_base / rel_path() / 'pkgB').write_text('')
-                (install_base / rel_path() / 'pkgC').write_text('')
-
-                marker_file.write_text('isolated')
-                packages = find_installed_packages(install_base)
-                assert len(packages) == 1
-                assert 'pkgA' in packages.keys()
-                assert packages['pkgA'] == install_base / 'pkgA'
-
-                marker_file.write_text('merged')
-                packages = find_installed_packages(install_base)
-                assert len(packages) == 2
-                assert 'pkgB' in packages.keys()
-                assert packages['pkgC'] == install_base
-                assert 'pkgC' in packages.keys()
-                assert packages['pkgB'] == install_base
+            packages = find_installed_packages(tmp_path)
+            assert len(packages) == 2
+            assert 'pkgB' in packages.keys()
+            assert packages['pkgC'] == tmp_path
+            assert 'pkgC' in packages.keys()
+            assert packages['pkgB'] == tmp_path
 
 
 class FIExtensionPathNotExist(FindInstalledPackagesExtensionPoint):
@@ -465,42 +450,37 @@ class FIExtensionPathNotExist(FindInstalledPackagesExtensionPoint):
         return {'pkgA': Path('/does/not/exist')}
 
 
-def test_inconsistent_package_finding_extensions():
+def test_inconsistent_package_finding_extensions(tmp_path):
     with ExtensionPointContext(dne=FIExtensionPathNotExist):
-        with TemporaryDirectory(prefix='test_colcon_') as install_base:
-            install_base = Path(install_base)
-            with patch('colcon_core.shell.logger.warning') as mock_warn:
-                assert {} == find_installed_packages(install_base)
-                dne_path = Path('/does/not/exist')
-                mock_warn.assert_called_once_with(
-                    "Ignoring 'pkgA' found at '{0}'"
-                    ' because the path does not exist.'.format(dne_path))
+        with patch('colcon_core.shell.logger.warning') as mock_warn:
+            assert {} == find_installed_packages(tmp_path)
+            dne_path = Path('/does/not/exist')
+            mock_warn.assert_called_once_with(
+                f"Ignoring 'pkgA' found at '{dne_path}' because the path does "
+                'not exist.')
 
 
-def test_find_package_two_locations():
-    with TemporaryDirectory(prefix='test_colcon_') as base:
-        base = Path(base)
-        location1 = base / 'pkgA'
-        location2 = base / 'pkgB'
-        location1.mkdir()
-        location2.mkdir()
+def test_find_package_two_locations(tmp_path):
+    location1 = tmp_path / 'pkgA'
+    location2 = tmp_path / 'pkgB'
+    location1.mkdir()
+    location2.mkdir()
 
-        class PackageLocation1(FindInstalledPackagesExtensionPoint):
+    class PackageLocation1(FindInstalledPackagesExtensionPoint):
 
-            def find_installed_packages(self, base: Path):
-                return {'pkgA': location1}
+        def find_installed_packages(self, base: Path):
+            return {'pkgA': location1}
 
-        class PackageLocation2(FindInstalledPackagesExtensionPoint):
+    class PackageLocation2(FindInstalledPackagesExtensionPoint):
 
-            def find_installed_packages(self, base: Path):
-                return {'pkgA': location2}
+        def find_installed_packages(self, base: Path):
+            return {'pkgA': location2}
 
-        with ExtensionPointContext(
-            loc1=PackageLocation1, loc2=PackageLocation2
-        ):
-            with patch('colcon_core.shell.logger.warning') as mock_warn:
-                assert {'pkgA': location1} == find_installed_packages(base)
-                mock_warn.assert_called_once_with(
-                    "The package 'pkgA' previously found at"
-                    f" '{location1}' was found again at '{location2}'."
-                    f" Ignoring '{location2}'")
+    with ExtensionPointContext(
+        loc1=PackageLocation1, loc2=PackageLocation2
+    ):
+        with patch('colcon_core.shell.logger.warning') as mock_warn:
+            assert {'pkgA': location1} == find_installed_packages(tmp_path)
+            mock_warn.assert_called_once_with(
+                f"The package 'pkgA' previously found at '{location1}' was "
+                f"found again at '{location2}'. Ignoring '{location2}'")

--- a/test/test_shell_bat.py
+++ b/test/test_shell_bat.py
@@ -2,9 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core import shell
@@ -18,13 +16,12 @@ import pytest
 from .run_until_complete import run_until_complete
 
 
-def test_extension():
+def test_extension(tmp_path):
     use_all_shell_extensions = shell.use_all_shell_extensions
     shell.use_all_shell_extensions = True
     try:
-        with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-            _test_extension(Path(prefix_path))
-            _test_prefix_script(Path(prefix_path))
+        _test_extension(tmp_path)
+        _test_prefix_script(tmp_path)
     finally:
         shell.use_all_shell_extensions = use_all_shell_extensions
 

--- a/test/test_shell_sh.py
+++ b/test/test_shell_sh.py
@@ -2,9 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core import shell
@@ -19,13 +17,12 @@ import pytest
 from .run_until_complete import run_until_complete
 
 
-def test_extension():
+def test_extension(tmp_path):
     use_all_shell_extensions = shell.use_all_shell_extensions
     shell.use_all_shell_extensions = True
     try:
-        with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-            _test_extension(Path(prefix_path))
-            _test_prefix_script(Path(prefix_path))
+        _test_extension(tmp_path)
+        _test_prefix_script(tmp_path)
     finally:
         shell.use_all_shell_extensions = use_all_shell_extensions
 

--- a/test/test_shell_template.py
+++ b/test/test_shell_template.py
@@ -1,9 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.shell.template import expand_template
@@ -11,55 +9,52 @@ from em import TransientParseError
 import pytest
 
 
-def test_expand_template():
-    with TemporaryDirectory(prefix='test_colcon_') as base_path:
-        template_path = Path(base_path) / 'template.em'
-        destination_path = Path(base_path) / 'expanded_template'
+def test_expand_template(tmp_path):
+    template_path = tmp_path / 'template.em'
+    destination_path = tmp_path / 'expanded_template'
 
-        # invalid template, missing @[end if]
-        template_path.write_text(
-            '@[if True]')
-        with pytest.raises(TransientParseError):
-            with patch('colcon_core.shell.template.logger.error') as error:
-                expand_template(template_path, destination_path, {})
-        # the raised exception is catched and results in an error message
-        assert error.call_count == 1
-        assert len(error.call_args[0]) == 1
-        assert error.call_args[0][0].endswith(
-            f" processing template '{template_path}'")
-        assert not destination_path.exists()
+    # invalid template, missing @[end if]
+    template_path.write_text('@[if True]')
+    with pytest.raises(TransientParseError):
+        with patch('colcon_core.shell.template.logger.error') as error:
+            expand_template(template_path, destination_path, {})
+    # the raised exception is catched and results in an error message
+    assert error.call_count == 1
+    assert len(error.call_args[0]) == 1
+    assert error.call_args[0][0].endswith(
+        f" processing template '{template_path}'")
+    assert not destination_path.exists()
 
-        # missing variable
-        template_path.write_text(
-            '@(var)')
-        with pytest.raises(NameError):
-            with patch('colcon_core.shell.template.logger.error') as error:
-                expand_template(template_path, destination_path, {})
-        # the raised exception is catched and results in an error message
-        assert error.call_count == 1
-        assert len(error.call_args[0]) == 1
-        assert error.call_args[0][0].endswith(
-            f" processing template '{template_path}'")
-        assert not destination_path.exists()
+    # missing variable
+    template_path.write_text('@(var)')
+    with pytest.raises(NameError):
+        with patch('colcon_core.shell.template.logger.error') as error:
+            expand_template(template_path, destination_path, {})
+    # the raised exception is catched and results in an error message
+    assert error.call_count == 1
+    assert len(error.call_args[0]) == 1
+    assert error.call_args[0][0].endswith(
+        f" processing template '{template_path}'")
+    assert not destination_path.exists()
 
-        # proper use
-        expand_template(template_path, destination_path, {'var': 'value1'})
-        assert destination_path.exists()
-        assert destination_path.read_text() == 'value1'
-        # overwrite with a different value
-        expand_template(template_path, destination_path, {'var': 'value2'})
-        assert destination_path.exists()
-        assert destination_path.read_text() == 'value2'
+    # proper use
+    expand_template(template_path, destination_path, {'var': 'value1'})
+    assert destination_path.exists()
+    assert destination_path.read_text() == 'value1'
+    # overwrite with a different value
+    expand_template(template_path, destination_path, {'var': 'value2'})
+    assert destination_path.exists()
+    assert destination_path.read_text() == 'value2'
 
-        destination_path.unlink()
+    destination_path.unlink()
 
-        # skip all symlink tests on Windows for now
-        if sys.platform == 'win32':  # pragma: no cover
-            return
+    # skip all symlink tests on Windows for now
+    if sys.platform == 'win32':  # pragma: no cover
+        return
 
-        # remove destination if it is a symlink
-        destination_path.symlink_to(template_path)
-        assert destination_path.is_symlink()
-        expand_template(template_path, destination_path, {'var': 'value'})
-        assert not destination_path.is_symlink()
-        assert destination_path.exists()
+    # remove destination if it is a symlink
+    destination_path.symlink_to(template_path)
+    assert destination_path.is_symlink()
+    expand_template(template_path, destination_path, {'var': 'value'})
+    assert not destination_path.is_symlink()
+    assert destination_path.exists()

--- a/test/test_shell_template_prefix_util.py
+++ b/test/test_shell_template_prefix_util.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.location import get_relative_package_index_path
@@ -25,51 +23,47 @@ def test_main(capsys):
     assert not err
 
 
-def test_get_packages():
-    with TemporaryDirectory(prefix='test_colcon_') as prefix_path:
-        prefix_path = Path(prefix_path)
+def test_get_packages(tmp_path):
+    # check no packages in not merged install layout
+    packages = get_packages(tmp_path, False)
+    assert packages == {}
 
-        # check no packages in not merged install layout
-        packages = get_packages(prefix_path, False)
-        assert packages == {}
+    # mock packages in not merged install layout
+    subdirectory = get_relative_package_index_path()
+    for pkg_name in ('pkgA', 'pkgB'):
+        (tmp_path / pkg_name / subdirectory).mkdir(parents=True)
+        (tmp_path / pkg_name / subdirectory / pkg_name).write_text('depX')
+    (tmp_path / 'dummy_dir').mkdir()
+    (tmp_path / '.hidden_dir').mkdir()
+    (tmp_path / 'dummy_file').write_text('')
 
-        # mock packages in not merged install layout
-        subdirectory = get_relative_package_index_path()
-        for pkg_name in ('pkgA', 'pkgB'):
-            (prefix_path / pkg_name / subdirectory).mkdir(parents=True)
-            (prefix_path / pkg_name / subdirectory / pkg_name).write_text(
-                'depX')
-        (prefix_path / 'dummy_dir').mkdir()
-        (prefix_path / '.hidden_dir').mkdir()
-        (prefix_path / 'dummy_file').write_text('')
+    # check no packages in merged install layout
+    packages = get_packages(tmp_path, True)
+    assert packages == {}
 
-        # check no packages in merged install layout
-        packages = get_packages(prefix_path, True)
-        assert packages == {}
+    # mock packages in merged install layout
+    (tmp_path / subdirectory).mkdir(parents=True)
+    (tmp_path / subdirectory / 'pkgB').write_text('')
+    (tmp_path / subdirectory / 'pkgC').write_text(
+        os.pathsep.join(('pkgB', 'depC')))
+    (tmp_path / subdirectory / 'dummy_dir').mkdir()
+    (tmp_path / subdirectory / '.hidden_file').write_text('')
 
-        # mock packages in merged install layout
-        (prefix_path / subdirectory).mkdir(parents=True)
-        (prefix_path / subdirectory / 'pkgB').write_text('')
-        (prefix_path / subdirectory / 'pkgC').write_text(
-            os.pathsep.join(('pkgB', 'depC')))
-        (prefix_path / subdirectory / 'dummy_dir').mkdir()
-        (prefix_path / subdirectory / '.hidden_file').write_text('')
+    # check packages and dependencies in not merged install layout
+    packages = get_packages(tmp_path, False)
+    assert len(packages) == 2
+    assert 'pkgA' in packages
+    assert packages['pkgA'] == set()
+    assert 'pkgB' in packages
+    assert packages['pkgB'] == set()
 
-        # check packages and dependencies in not merged install layout
-        packages = get_packages(prefix_path, False)
-        assert len(packages) == 2
-        assert 'pkgA' in packages
-        assert packages['pkgA'] == set()
-        assert 'pkgB' in packages
-        assert packages['pkgB'] == set()
-
-        # check packages and dependencies in not merged install layout
-        packages = get_packages(prefix_path, True)
-        assert len(packages) == 2
-        assert 'pkgB' in packages
-        assert packages['pkgB'] == set()
-        assert 'pkgC' in packages
-        assert packages['pkgC'] == {'pkgB'}
+    # check packages and dependencies in not merged install layout
+    packages = get_packages(tmp_path, True)
+    assert len(packages) == 2
+    assert 'pkgB' in packages
+    assert packages['pkgB'] == set()
+    assert 'pkgC' in packages
+    assert packages['pkgC'] == {'pkgB'}
 
 
 def test_order_packages():

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -2,9 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import os
-from pathlib import Path
 import sys
-from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -163,96 +161,94 @@ def test_get_task_extension():
         assert isinstance(extension, Extension2)
 
 
-def test_create_file():
-    with TemporaryDirectory(prefix='test_colcon_') as base_path:
-        args = Mock()
-        args.install_base = base_path
+def test_create_file(tmp_path):
+    args = Mock()
+    args.install_base = str(tmp_path)
 
-        create_file(args, 'file.txt')
-        path = Path(base_path) / 'file.txt'
-        assert path.is_file()
-        assert path.read_text() == ''
+    create_file(args, 'file.txt')
+    path = tmp_path / 'file.txt'
+    assert path.is_file()
+    assert path.read_text() == ''
 
-        create_file(args, 'path/file.txt', content='content')
-        path = Path(base_path) / 'path' / 'file.txt'
-        assert path.is_file()
-        assert path.read_text() == 'content'
+    create_file(args, 'path/file.txt', content='content')
+    path = tmp_path / 'path' / 'file.txt'
+    assert path.is_file()
+    assert path.read_text() == 'content'
 
 
-def test_install():
-    with TemporaryDirectory(prefix='test_colcon_') as base_path:
-        args = Mock()
-        args.path = os.path.join(base_path, 'path')
-        args.install_base = os.path.join(base_path, 'install')
-        args.symlink_install = False
+def test_install(tmp_path):
+    args = Mock()
+    args.path = str(tmp_path / 'path')
+    args.install_base = str(tmp_path / 'install')
+    args.symlink_install = False
 
-        # create source files
-        os.makedirs(args.path)
-        with open(os.path.join(args.path, 'source.txt'), 'w') as h:
-            h.write('content')
-        with open(os.path.join(args.path, 'source2.txt'), 'w') as h:
-            h.write('content2')
+    # create source files
+    os.makedirs(args.path)
+    with open(os.path.join(args.path, 'source.txt'), 'w') as h:
+        h.write('content')
+    with open(os.path.join(args.path, 'source2.txt'), 'w') as h:
+        h.write('content2')
 
-        # copy file
-        install(args, 'source.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert not path.is_symlink()
-        assert path.read_text() == 'content'
+    # copy file
+    install(args, 'source.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert not path.is_symlink()
+    assert path.read_text() == 'content'
 
-        # skip all symlink tests on Windows for now
-        if sys.platform == 'win32':  # pragma: no cover
-            return
+    # skip all symlink tests on Windows for now
+    if sys.platform == 'win32':  # pragma: no cover
+        return
 
-        # symlink file, removing existing file
-        args.symlink_install = True
-        install(args, 'source.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert path.is_symlink()
-        assert path.samefile(os.path.join(args.path, 'source.txt'))
-        assert path.read_text() == 'content'
+    # symlink file, removing existing file
+    args.symlink_install = True
+    install(args, 'source.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert path.is_symlink()
+    assert path.samefile(os.path.join(args.path, 'source.txt'))
+    assert path.read_text() == 'content'
 
-        # symlink other file, removing existing directory
-        os.remove(os.path.join(args.install_base, 'destination.txt'))
-        os.makedirs(os.path.join(args.install_base, 'destination.txt'))
-        install(args, 'source2.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert path.is_symlink()
-        assert path.samefile(os.path.join(args.path, 'source2.txt'))
-        assert path.read_text() == 'content2'
+    # symlink other file, removing existing directory
+    os.remove(os.path.join(args.install_base, 'destination.txt'))
+    os.makedirs(os.path.join(args.install_base, 'destination.txt'))
+    install(args, 'source2.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert path.is_symlink()
+    assert path.samefile(os.path.join(args.path, 'source2.txt'))
+    assert path.read_text() == 'content2'
 
-        # copy file, removing existing symlink
-        args.symlink_install = False
-        install(args, 'source.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert not path.is_symlink()
-        assert path.read_text() == 'content'
+    # copy file, removing existing symlink
+    args.symlink_install = False
+    install(args, 'source.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert not path.is_symlink()
+    assert path.read_text() == 'content'
 
-        # symlink file
-        os.remove(os.path.join(args.install_base, 'destination.txt'))
-        args.symlink_install = True
-        install(args, 'source.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert path.is_symlink()
-        assert path.samefile(os.path.join(args.path, 'source.txt'))
-        assert path.read_text() == 'content'
+    # symlink file
+    os.remove(os.path.join(args.install_base, 'destination.txt'))
+    args.symlink_install = True
+    install(args, 'source.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert path.is_symlink()
+    assert path.samefile(os.path.join(args.path, 'source.txt'))
+    assert path.read_text() == 'content'
 
-        # symlink file, same already existing
-        install(args, 'source.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert path.is_symlink()
-        assert path.samefile(os.path.join(args.path, 'source.txt'))
-        assert path.read_text() == 'content'
+    # symlink file, same already existing
+    install(args, 'source.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert path.is_symlink()
+    assert path.samefile(os.path.join(args.path, 'source.txt'))
+    assert path.read_text() == 'content'
 
-        # symlink exists, but to a not existing location
-        os.remove(os.path.join(args.path, 'source.txt'))
-        install(args, 'source2.txt', 'destination.txt')
-        path = Path(base_path) / 'install' / 'destination.txt'
-        assert path.is_file()
-        assert path.is_symlink()
-        assert path.samefile(os.path.join(args.path, 'source2.txt'))
+    # symlink exists, but to a not existing location
+    os.remove(os.path.join(args.path, 'source.txt'))
+    install(args, 'source2.txt', 'destination.txt')
+    path = tmp_path / 'install' / 'destination.txt'
+    assert path.is_file()
+    assert path.is_symlink()
+    assert path.samefile(os.path.join(args.path, 'source2.txt'))

--- a/test/test_verb.py
+++ b/test/test_verb.py
@@ -3,8 +3,6 @@
 
 import argparse
 import logging
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from colcon_core.verb import check_and_mark_build_tool
@@ -39,69 +37,63 @@ def test_get_verb_extensions():
     assert list(extensions.keys()) == ['extension1', 'extension2']
 
 
-def test_check_and_mark_build_tool():
-    with TemporaryDirectory(prefix='test_colcon_') as base_path:
-        base_path = Path(base_path)
+def test_check_and_mark_build_tool(tmp_path):
+    # create marker if it doesn't exist
+    check_and_mark_build_tool(str(tmp_path))
+    marker_path = tmp_path / '.built_by'
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'colcon'
 
-        # create marker if it doesn't exist
-        check_and_mark_build_tool(str(base_path))
-        marker_path = base_path / '.built_by'
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'colcon'
+    # create path and marker if it doesn't exist
+    path = tmp_path / 'no_base'
+    check_and_mark_build_tool(str(path))
+    assert path.exists()
+    marker_path = path / '.built_by'
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'colcon'
 
-        # create path and marker if it doesn't exist
-        path = base_path / 'no_base'
+    # existing marker with same content
+    path = tmp_path / 'existing_marker'
+    path.mkdir()
+    marker_path = path / '.built_by'
+    marker_path.write_text('colcon')
+    check_and_mark_build_tool(str(path))
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'colcon'
+
+    # existing marker with different content
+    marker_path.write_text('other')
+    with pytest.raises(RuntimeError):
         check_and_mark_build_tool(str(path))
-        assert path.exists()
-        marker_path = path / '.built_by'
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'colcon'
-
-        # existing marker with same content
-        path = base_path / 'existing_marker'
-        path.mkdir()
-        marker_path = path / '.built_by'
-        marker_path.write_text('colcon')
-        check_and_mark_build_tool(str(path))
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'colcon'
-
-        # existing marker with different content
-        marker_path.write_text('other')
-        with pytest.raises(RuntimeError):
-            check_and_mark_build_tool(str(path))
 
 
-def test_check_and_mark_install_layout():
-    with TemporaryDirectory(prefix='test_colcon_') as base_path:
-        base_path = Path(base_path)
+def test_check_and_mark_install_layout(tmp_path):
+    # create marker if it doesn't exist
+    check_and_mark_install_layout(str(tmp_path), merge_install=False)
+    marker_path = tmp_path / '.colcon_install_layout'
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'isolated'
 
-        # create marker if it doesn't exist
-        check_and_mark_install_layout(str(base_path), merge_install=False)
-        marker_path = base_path / '.colcon_install_layout'
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'isolated'
+    # create path and marker if it doesn't exist
+    path = tmp_path / 'no_base'
+    check_and_mark_install_layout(str(path), merge_install=True)
+    assert path.exists()
+    marker_path = path / '.colcon_install_layout'
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'merged'
 
-        # create path and marker if it doesn't exist
-        path = base_path / 'no_base'
-        check_and_mark_install_layout(str(path), merge_install=True)
-        assert path.exists()
-        marker_path = path / '.colcon_install_layout'
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'merged'
+    # existing marker with same content
+    check_and_mark_install_layout(str(path), merge_install=True)
+    assert marker_path.exists()
+    assert marker_path.read_text().rstrip() == 'merged'
 
-        # existing marker with same content
-        check_and_mark_install_layout(str(path), merge_install=True)
-        assert marker_path.exists()
-        assert marker_path.read_text().rstrip() == 'merged'
+    # existing marker with different content
+    with pytest.raises(RuntimeError):
+        check_and_mark_install_layout(str(path), merge_install=False)
 
-        # existing marker with different content
-        with pytest.raises(RuntimeError):
-            check_and_mark_install_layout(str(path), merge_install=False)
-
-        # install base which is a file
-        with pytest.raises(RuntimeError):
-            check_and_mark_install_layout(str(marker_path), merge_install=True)
+    # install base which is a file
+    with pytest.raises(RuntimeError):
+        check_and_mark_install_layout(str(marker_path), merge_install=True)
 
 
 def test_update_object():

--- a/test/test_verb_build.py
+++ b/test/test_verb_build.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
-import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -91,7 +90,7 @@ def test_add_arguments():
     assert parser.add_argument.call_count > 4
 
 
-def test_verb_test(tmpdir):
+def test_verb_test(tmp_path):
     extension = BuildVerb()
     extension.add_arguments(parser=Mock())
 
@@ -99,8 +98,8 @@ def test_verb_test(tmpdir):
         command_name='colcon',
         args=Mock())
 
-    context.args.build_base = os.path.join(tmpdir, 'build')
-    context.args.install_base = os.path.join(tmpdir, 'install')
-    context.args.test_result_base = os.path.join(tmpdir, 'test_results')
+    context.args.build_base = str(tmp_path / 'build')
+    context.args.install_base = str(tmp_path / 'install')
+    context.args.test_result_base = str(tmp_path / 'test_results')
 
     assert 0 == extension.main(context=context)

--- a/test/test_verb_test.py
+++ b/test/test_verb_test.py
@@ -1,7 +1,6 @@
 # Copyright 2024 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
-import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -91,7 +90,7 @@ def test_add_arguments():
     assert parser.add_argument.call_count > 4
 
 
-def test_verb_test(tmpdir):
+def test_verb_test(tmp_path):
     extension = TestVerb()
     extension.add_arguments(parser=Mock())
 
@@ -99,8 +98,8 @@ def test_verb_test(tmpdir):
         command_name='colcon',
         args=Mock())
 
-    context.args.build_base = os.path.join(tmpdir, 'build')
-    context.args.install_base = os.path.join(tmpdir, 'install')
-    context.args.test_result_base = os.path.join(tmpdir, 'test_results')
+    context.args.build_base = str(tmp_path / 'build')
+    context.args.install_base = str(tmp_path / 'install')
+    context.args.test_result_base = str(tmp_path / 'test_results')
 
     assert 0 == extension.main(context=context)


### PR DESCRIPTION
This package was previously using three different temporary directory allocation strategies:
- Manual `TemporaryDirectory` management
- pytest `tmpdir` fixture
- pytest `tmp_path` fixture

This commit changes all temporary directory allocation in tests to use the `tmp_path` fixture, and includes a compatibility definition of that fixture so that the tests will continue to work properly on Enterprise Linux 8.

---

I'm not expecting a thorough review of this change. Only test files were touched, and the pattern is largely the same in each. The goal here is to move the codebase to more modern testing patterns while maintaining compatibility with the platforms we support. Additionally, the vast majority of the line changes are removing indentation that's no longer necessary.