### PR TITLE
Suppress E402 in test for older linter versions

### DIFF
--- a/test/test_entry_point.py
+++ b/test/test_entry_point.py
@@ -26,7 +26,7 @@ with warnings.catch_warnings():
                 allow_module_level=True)
         raise
 
-from .environment_context import EnvironmentContext
+from .environment_context import EnvironmentContext  # noqa: E402
 
 
 class Group1:


### PR DESCRIPTION
It seems that older linter versions complain about this import, and newer linters don't mind the suppression.