### PR TITLE
Improve argument coloring where available

### DIFF
--- a/colcon_core/command.py
+++ b/colcon_core/command.py
@@ -19,8 +19,8 @@ from colcon_core.environment_variable import EnvironmentVariable
 """Environment variable to set the warnings filter for colcon modules"""
 WARNINGS_ENVIRONMENT_VARIABLE = EnvironmentVariable(
     'COLCON_WARNINGS',
-    'Set the warnings filter similar to PYTHONWARNINGS except that the module '
-    "entry is implicitly set to 'colcon.*'")
+    'Set the warnings filter similar to `PYTHONWARNINGS` except that the '
+    'module entry is implicitly set to `colcon.*`')
 
 warnings_filters = os.environ.get(WARNINGS_ENVIRONMENT_VARIABLE.name)
 if warnings_filters:
@@ -75,7 +75,7 @@ LOG_LEVEL_ENVIRONMENT_VARIABLE = EnvironmentVariable(
 """Environment variable to set the configuration directory"""
 HOME_ENVIRONMENT_VARIABLE = EnvironmentVariable(
     'COLCON_HOME',
-    'Set the configuration directory (default: ~/.colcon)')
+    'Set the configuration directory (default: `~/.colcon`)')
 
 
 _command_exit_handlers = []
@@ -379,12 +379,12 @@ def add_log_level_argument(parser):
     """
     parser.add_argument(
         '--log-base',
-        help='The base path for all log directories (default: ./log, to '
-             f'disable: {os.devnull})')
+        help='The base path for all log directories (default: `./log`, to '
+             f'disable: `{os.devnull}`)')
     parser.add_argument(
         '--log-level', action=LogLevelAction,
         help='Set log level for the console output, either by numeric or '
-             'string value (default: warning)')
+             'string value (default: `warning`)')
 
 
 class LogLevelAction(argparse.Action):

--- a/colcon_core/executor/__init__.py
+++ b/colcon_core/executor/__init__.py
@@ -254,7 +254,7 @@ def add_executor_arguments(parser):
 
     group.add_argument(
         '--executor', type=str, choices=keys, default=default,
-        help=f'The executor to process all packages (default: {default})'
+        help=f'The executor to process all packages (default: %(default)s)'
              f'{descriptions}')  # noqa: E131
 
     for priority in extensions.keys():

--- a/colcon_core/package_discovery/path.py
+++ b/colcon_core/package_discovery/path.py
@@ -36,7 +36,7 @@ class PathPackageDiscovery(PackageDiscoveryExtensionPoint):
             type=get_cwd_path_resolver(),
             help='The paths to check for a package. Use shell wildcards '
                  '(e.g. `src/*`) to select all direct subdirectories' +
-                 (' (default: .)' if with_default else ''))
+                 (' (default: `.`)' if with_default else ''))
 
     def has_parameters(self, *, args):  # noqa: D102
         return not is_default_value(args.paths) and \

--- a/colcon_core/task/python/test/pytest.py
+++ b/colcon_core/task/python/test/pytest.py
@@ -39,7 +39,7 @@ class PytestPythonTestingStep(PythonTestingStepExtensionPoint):
             nargs='*', metavar='*', type=str.lstrip,
             help='Pass arguments to pytests. '
             'Arguments matching other options must be prefixed by a space,\n'
-            'e.g. --pytest-args " --help" (stdout might not be shown by '
+            'e.g. `--pytest-args " --help"` (stdout might not be shown by '
             'default, e.g. add `--event-handlers console_cohesion+`)')
         parser.add_argument(
             '--pytest-with-coverage',

--- a/colcon_core/task/python/test/setuppy_test.py
+++ b/colcon_core/task/python/test/setuppy_test.py
@@ -23,7 +23,7 @@ class SetuppyPythonTestingStep(PythonTestingStepExtensionPoint):
             nargs='*', metavar='*', type=str.lstrip,
             help='Pass arguments to Python unittests. '
             'Arguments matching other options must be prefixed by a space,\n'
-            'e.g. --unittest-args " --help" (stdout might not be shown by '
+            'e.g. `--unittest-args " --help"` (stdout might not be shown by '
             'default, e.g. add `--event-handlers console_cohesion+`)')
 
     def match(self, context, env, setup_py_data):  # noqa: D102

--- a/colcon_core/verb/build.py
+++ b/colcon_core/verb/build.py
@@ -86,12 +86,14 @@ class BuildVerb(VerbExtensionPoint):
             '--build-base',
             default=wrap_default_value('build'),
             type=get_cwd_path_resolver(),
-            help='The base path for all build directories (default: build)')
+            help='The base path for all build directories '
+                 '(default: %(default)s)')
         parser.add_argument(
             '--install-base',
             default=wrap_default_value('install'),
             type=get_cwd_path_resolver(),
-            help='The base path for all install prefixes (default: install)')
+            help='The base path for all install prefixes '
+                 '(default: %(default)s)')
         parser.add_argument(
             '--merge-install',
             action='store_true',
@@ -103,7 +105,8 @@ class BuildVerb(VerbExtensionPoint):
         parser.add_argument(
             '--test-result-base',
             type=get_cwd_path_resolver(),
-            help='The base path for all test results (default: --build-base)')
+            help='The base path for all test results '
+                 '(default: same as `--build-base`)')
         parser.add_argument(
             '--continue-on-error',
             action='store_true',

--- a/colcon_core/verb/test.py
+++ b/colcon_core/verb/test.py
@@ -103,7 +103,8 @@ class TestVerb(VerbExtensionPoint):
         parser.add_argument(
             '--test-result-base',
             type=get_cwd_path_resolver(),
-            help='The base path for all test results (default: --build-base)')
+            help='The base path for all test results '
+                 '(default: same as `--build-base`)')
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             '--retest-until-fail',


### PR DESCRIPTION
* Use %(default)s where appropriate
* Otherwise, use backticks around default values
* Use backticks when referring to console commands, such as references to other command line options or example command invocations

Example with Python 3.15:
<img width="800" height="480" alt="out" src="https://github.com/user-attachments/assets/bbe8ad86-7d41-4165-9f94-9b5a8fff764f" />

Note that we're not actually choosing the palette here, we're just giving `argparse` the information it needs to align with other console output.